### PR TITLE
Grammar issue in QuickLook accessing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Fuzzing         | --- | ---
 
 # Boost.URL
 
-## This is currently **NOT** an official Boost library.
-
 ## Overview
 
 Boost.URL is a portable C++ library which provides containers and algorithms

--- a/doc/qbk/2.0.quicklook.qbk
+++ b/doc/qbk/2.0.quicklook.qbk
@@ -325,7 +325,7 @@ not require dynamic memory allocations.
 [snippet_quicklook_modifying_1b]
 
 Objects of type __url__ are [@https://en.cppreference.com/w/cpp/concepts/regular std::regular].
-Similarly to built-in types, such as `int`, a __url__ is copiable, movable, assignable, default
+Similarly to built-in types, such as `int`, a __url__ is copyable, movable, assignable, default
 constructible, and equality comparable. They support all of the inspection functions of
 __url_view__, and also provide functions to modify all components of the URL.
 

--- a/doc/qbk/2.0.quicklook.qbk
+++ b/doc/qbk/2.0.quicklook.qbk
@@ -156,7 +156,7 @@ These functions might also return empty strings
 
 [snippet_accessing_2a]
 
-for both for empty and absent components
+for both empty and absent components
 
 [snippet_accessing_2b]
 

--- a/example/route/route.cpp
+++ b/example/route/route.cpp
@@ -153,7 +153,7 @@ main(int argc, char **argv)
         exec = exec.filename();
         std::cerr
             << "Usage: " << exec.c_str()
-            << " <target> <prefix> <root>\n"
+            << " <target> <prefix> <doc_root>\n"
                "target: path to make a request\n"
                "prefix: url prefix\n"
                "doc_root: dir to look for files\n";

--- a/include/boost/url/pct_encoded_view.hpp
+++ b/include/boost/url/pct_encoded_view.hpp
@@ -54,11 +54,10 @@ class copied_strings_base;
     @li Comparison to encoded or plain strings
 
     However, in order to access the string as a
-    as a contiguous character buffer with
-    with percent-decoding applied, the caller
-    must explicitly opt-in to an operation that
-    is potentially allocating. These operations
-    are:
+    contiguous character buffer with percent-
+    -decoding applied, the caller must
+    explicitly opt-in to an operation that is
+    potentially allocating. These operations are:
 
     @li Conversion to `std::string`
     @li Appending to an existing character buffer


### PR DESCRIPTION
I'm not certain if this should be "…for both empty and…" or "…both for empty and…" (I think either would be correct), but I'm pretty certain that "…for both for…" is not correct.