### PR TITLE
comparison differentiates absent and empty components

### DIFF
--- a/include/boost/url/authority_view.hpp
+++ b/include/boost/url/authority_view.hpp
@@ -1228,6 +1228,152 @@ public:
     encoded_host_and_port() const noexcept;
 
     //--------------------------------------------
+    //
+    // Comparison
+    //
+    //--------------------------------------------
+
+    /** Return the result of comparing this with another authority
+
+        This function compares two authorities
+        according to Syntax-Based comparison
+        algorithm.
+
+        @par Exception Safety
+        Throws nothing.
+
+        @return -1 if `*this < other`, 0 if
+        `this == other`, and 1 if `this > other`.
+
+        @par Specification
+        @li <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2"
+            >6.2.2 Syntax-Based Normalization (rfc3986)</a>
+    */
+    BOOST_URL_DECL
+    int
+    compare(authority_view const& other) const noexcept;
+
+    /** Return the result of comparing two authorities
+        The authorities are compared component
+        by component as if they were first
+        normalized.
+
+        @par Complexity
+        Linear in `min( a0.size(), a1.size() )`
+
+        @par Exception Safety
+        Throws nothing
+    */
+    friend
+    bool
+    operator==(
+        authority_view const& a0,
+        authority_view const& a1) noexcept
+    {
+        return a0.compare(a1) == 0;
+    }
+
+    /** Return the result of comparing two authorities
+        The authorities are compared component
+        by component as if they were first
+        normalized.
+
+        @par Complexity
+        Linear in `min( a0.size(), a1.size() )`
+
+        @par Exception Safety
+        Throws nothing
+    */
+    friend
+    bool
+    operator!=(
+        authority_view const& a0,
+        authority_view const& a1) noexcept
+    {
+        return ! (a0 == a1);
+    }
+
+    /** Return the result of comparing two authorities
+        The authorities are compared component
+        by component as if they were first
+        normalized.
+
+        @par Complexity
+        Linear in `min( a0.size(), a1.size() )`
+
+        @par Exception Safety
+        Throws nothing
+    */
+    friend
+    bool
+    operator<(
+        authority_view const& a0,
+        authority_view const& a1) noexcept
+    {
+        return a0.compare(a1) < 0;
+    }
+
+    /** Return the result of comparing two authorities
+        The authorities are compared component
+        by component as if they were first
+        normalized.
+
+        @par Complexity
+        Linear in `min( a0.size(), a1.size() )`
+
+        @par Exception Safety
+        Throws nothing
+    */
+    friend
+    bool
+    operator<=(
+        authority_view const& a0,
+        authority_view const& a1) noexcept
+    {
+        return a0.compare(a1) <= 0;
+    }
+
+    /** Return the result of comparing two authorities
+        The authorities are compared component
+        by component as if they were first
+        normalized.
+
+        @par Complexity
+        Linear in `min( a0.size(), a1.size() )`
+
+        @par Exception Safety
+        Throws nothing
+    */
+    friend
+    bool
+    operator>(
+        authority_view const& a0,
+        authority_view const& a1) noexcept
+    {
+        return a0.compare(a1) > 0;
+    }
+
+    /** Return the result of comparing two authorities
+        The authorities are compared component
+        by component as if they were first
+        normalized.
+
+        @par Complexity
+        Linear in `min( a0.size(), a1.size() )`
+
+        @par Exception Safety
+        Throws nothing
+    */
+    friend
+    bool
+    operator>=(
+        authority_view const& a0,
+        authority_view const& a1) noexcept
+    {
+        return a0.compare(a1) >= 0;
+    }
+
+    //--------------------------------------------
 
     // hidden friend
     friend

--- a/include/boost/url/impl/authority_view.ipp
+++ b/include/boost/url/impl/authority_view.ipp
@@ -339,6 +339,67 @@ parse_authority(
     return grammar::parse(s, authority_rule);
 }
 
+//------------------------------------------------
+//
+// Comparisons
+//
+//------------------------------------------------
+
+int
+authority_view::
+compare(const authority_view& other) const noexcept
+{
+    auto comp = static_cast<int>(has_userinfo()) -
+        static_cast<int>(other.has_userinfo());
+    if ( comp != 0 )
+        return comp;
+
+    if (has_userinfo())
+    {
+        comp = detail::compare_encoded(
+            encoded_user(),
+            other.encoded_user());
+        if ( comp != 0 )
+            return comp;
+
+        comp = static_cast<int>(has_password()) -
+               static_cast<int>(other.has_password());
+        if ( comp != 0 )
+            return comp;
+
+        if (has_password())
+        {
+            comp = detail::compare_encoded(
+                encoded_password(),
+                other.encoded_password());
+            if ( comp != 0 )
+                return comp;
+        }
+    }
+
+    comp = detail::ci_compare_encoded(
+        encoded_host(),
+        other.encoded_host());
+    if ( comp != 0 )
+        return comp;
+
+    comp = static_cast<int>(has_port()) -
+           static_cast<int>(other.has_port());
+    if ( comp != 0 )
+        return comp;
+
+    if (has_port())
+    {
+        comp = detail::compare(
+            port(),
+            other.port());
+        if ( comp != 0 )
+            return comp;
+    }
+
+    return 0;
+}
+
 } // urls
 } // boost
 

--- a/include/boost/url/impl/url_view_base.ipp
+++ b/include/boost/url/impl/url_view_base.ipp
@@ -640,35 +640,33 @@ int
 url_view_base::
 compare(const url_view_base& other) const noexcept
 {
-    int comp = detail::ci_compare(
-        scheme(),
-        other.scheme());
+    int comp =
+        static_cast<int>(has_scheme()) -
+        static_cast<int>(other.has_scheme());
     if ( comp != 0 )
         return comp;
 
-    comp = detail::compare_encoded(
-        encoded_user(),
-        other.encoded_user());
+    if (has_scheme())
+    {
+        comp = detail::ci_compare(
+            scheme(),
+            other.scheme());
+        if ( comp != 0 )
+            return comp;
+    }
+
+    comp =
+        static_cast<int>(has_authority()) -
+        static_cast<int>(other.has_authority());
     if ( comp != 0 )
         return comp;
 
-    comp = detail::compare_encoded(
-        encoded_password(),
-        other.encoded_password());
-    if ( comp != 0 )
-        return comp;
-
-    comp = detail::ci_compare_encoded(
-        encoded_host(),
-        other.encoded_host());
-    if ( comp != 0 )
-        return comp;
-
-    comp = detail::compare(
-        port(),
-        other.port());
-    if ( comp != 0 )
-        return comp;
+    if (has_authority())
+    {
+        comp = authority().compare(other.authority());
+        if ( comp != 0 )
+            return comp;
+    }
 
     comp = detail::segments_compare(
         encoded_segments(),
@@ -676,17 +674,35 @@ compare(const url_view_base& other) const noexcept
     if ( comp != 0 )
         return comp;
 
-    comp = detail::compare_encoded(
-        encoded_query(),
-        other.encoded_query());
+    comp =
+        static_cast<int>(has_query()) -
+        static_cast<int>(other.has_query());
     if ( comp != 0 )
         return comp;
 
-    comp = detail::compare_encoded(
-        encoded_fragment(),
-        other.encoded_fragment());
+    if (has_query())
+    {
+        comp = detail::compare_encoded(
+            encoded_query(),
+            other.encoded_query());
+        if ( comp != 0 )
+            return comp;
+    }
+
+    comp =
+        static_cast<int>(has_fragment()) -
+        static_cast<int>(other.has_fragment());
     if ( comp != 0 )
         return comp;
+
+    if (has_fragment())
+    {
+        comp = detail::compare_encoded(
+            encoded_fragment(),
+            other.encoded_fragment());
+        if ( comp != 0 )
+            return comp;
+    }
 
     return 0;
 }

--- a/test/unit/url.cpp
+++ b/test/unit/url.cpp
@@ -995,6 +995,13 @@ struct url_test
             // issue 579
             check("https://www.boost.org/doc/../%69%6e%64%65%78%20file.html",
                   "https://www.boost.org/index%20file.html");
+            // issue 646
+            BOOST_TEST_NE(
+                url("https://@www.boost.org/"),
+                url("https://www.boost.org/"));
+            BOOST_TEST_NE(
+                url("https://:@www.boost.org/"),
+                url("https://@www.boost.org/"));
         }
 
         // normalize path


### PR DESCRIPTION
This PR simplifies the URL comparison function. It also fixes a bug where the difference between some absent and empty components was not considered. This fix was part of #425, which is now obsoleted.