### PR TITLE
make_error_code is constexpr

### DIFF
--- a/include/boost/url/impl/error.hpp
+++ b/include/boost/url/impl/error.hpp
@@ -48,18 +48,21 @@ struct BOOST_SYMBOL_VISIBLE
     }
 };
 
+BOOST_URL_DECL extern
+    error_cat_type error_cat;
+
 } // detail
 
 inline
+BOOST_SYSTEM_CONSTEXPR
 system::error_code
 make_error_code(
     error ev) noexcept
 {
-    static BOOST_SYSTEM_CONSTEXPR
-        detail::error_cat_type cat{};
     return system::error_code{
         static_cast<std::underlying_type<
-            error>::type>(ev), cat};
+            error>::type>(ev),
+        detail::error_cat};
 }
 
 } // urls

--- a/include/boost/url/impl/error.ipp
+++ b/include/boost/url/impl/error.ipp
@@ -81,7 +81,11 @@ return grammar::condition::fatal;
 # pragma warning( disable : 4592 )
 #endif
 
+#if defined(__cpp_constinit) && __cpp_constinit >= 201907L
+constinit error_cat_type error_cat;
+#else
 error_cat_type error_cat;
+#endif
 
 #if defined(_MSC_VER) && _MSC_VER <= 1900
 # pragma warning( pop )

--- a/include/boost/url/impl/error.ipp
+++ b/include/boost/url/impl/error.ipp
@@ -71,6 +71,22 @@ return grammar::condition::fatal;
     }
 }
 
+//-----------------------------------------------
+
+// msvc 14.0 has a bug that warns about inability
+// to use constexpr construction here, even though
+// there's no constexpr construction
+#if defined(_MSC_VER) && _MSC_VER <= 1900
+# pragma warning( push )
+# pragma warning( disable : 4592 )
+#endif
+
+error_cat_type error_cat;
+
+#if defined(_MSC_VER) && _MSC_VER <= 1900
+# pragma warning( pop )
+#endif
+
 } // detail
 
 } // urls


### PR DESCRIPTION
This replicates how http-proto does error codes: 

https://github.com/CPPAlliance/http_proto/commit/dc7d2730b8d5cc5fba1d4900459eb9467289bdfc