### PR TITLE
path_iter "/" is fast_nseg zero

### DIFF
--- a/include/boost/url/detail/impl/any_segments_iter.ipp
+++ b/include/boost/url/detail/impl/any_segments_iter.ipp
@@ -78,6 +78,11 @@ rewind() noexcept
         {
             ++p0;
             ++pos_;
+            if (p0 == end)
+            {
+                fast_nseg = 0;
+                pos_ = string_view::npos;
+            }
         }
         auto p = p0;
         while(p != end)

--- a/test/unit/segments_encoded_ref.cpp
+++ b/test/unit/segments_encoded_ref.cpp
@@ -286,6 +286,7 @@ struct segments_encoded_ref_test
         // insert(iterator, pct_string_view)
         //
 
+        // inserting extra "" as first segment
         {
             auto const f = [](segments_encoded_ref ps)
             {
@@ -297,6 +298,9 @@ struct segments_encoded_ref_test
                     "%%"), system_error);
             };
             check(f, "", "./", {""});
+            // path "/" represents empty segment range: {}
+            BOOST_TEST(url_view("/").encoded_segments().empty());
+            // path "/./" represents segment range: {""}
             check(f, "/", "/./", {""});
             check(f, "/index.htm", "/.//index.htm", {"", "index.htm"});
             check(f, "index.htm", ".//index.htm", {"", "index.htm"});
@@ -495,15 +499,16 @@ struct segments_encoded_ref_test
         // replace(iterator, pct_string_view)
         //
 
+        // replace first with empty segment
         {
             auto const f = [](segments_encoded_ref ps)
             {
-                auto it = ps.replace(std::next(ps.begin(), 0), "");
+                auto it = ps.replace(ps.begin(), "");
                 BOOST_TEST_EQ(*it, "");
 
                 // invalid percent escape
-                BOOST_TEST_THROWS(ps.replace(std::next(ps.begin(), 0),
-                    "00%"), system_error);
+                BOOST_TEST_THROWS(ps.replace(
+                    ps.begin(), "00%"), system_error);
             };
             check(f, "path/to/file.txt", ".//to/file.txt", {"", "to", "file.txt"});
             check(f, "/path/to/file.txt", "/.//to/file.txt", {"", "to", "file.txt"});

--- a/test/unit/url.cpp
+++ b/test/unit/url.cpp
@@ -302,6 +302,21 @@ struct url_test
             u.set_path_absolute( false );
             BOOST_TEST_EQ( u.buffer(), "./kyle:xy" );
         }
+        {
+            // issue 674: 1
+            auto ok = [](string_view u0, string_view p)
+            {
+                urls::url u(u0);
+                u.set_path(p);
+                BOOST_TEST_CSTR_EQ(u.buffer(), p);
+                u.normalize();
+                BOOST_TEST_CSTR_EQ(u.buffer(), p);
+            };
+            ok("/", "/");
+            ok("/", "");
+            ok("", "/");
+            ok("", "");
+        }
 
         // set_encoded_path
         {
@@ -367,8 +382,8 @@ struct url_test
             {
                 url u = parse_uri_reference(s0).value();
                 u.set_encoded_path(arg);
-                BOOST_TEST(
-                    u.buffer() == match);
+                BOOST_TEST_CSTR_EQ(
+                    u.buffer(), match);
             };
             check(
                 "",


### PR DESCRIPTION
This PR fixes the first issue in https://github.com/boostorg/url/issues/674

`path_iter` was identifying `"/"` as having `fast_nseg == 1` while it should be `0` according to the library convention that `"/"` represents `{}`  and `"/./"` represents `{""}`.

This led to counterintuitive results like:

```cpp
assert(url("/").set_path("/").buffer() == "/./");
```

A second problem with this convention is that when we normalize a path from `"/./"` to its equivalent `"/"`, the segments representation goes from `{""}` to `{}`, but there's nothing we can or should do about that.