### PR TITLE
Update drone caching strategy

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -410,7 +410,7 @@ def generate(compiler_ranges, cxx_range, max_cxx=2, coverage=True, docs=True, as
 
         if cache_dir != None and image_supports_caching(image, compiler):
             environment['drone_cache_mount'] = cache_dir
-            if image in images_used:
+            if image in images_used or buildtype != "boost":
                 environment['drone_cache_rebuild'] = 'false'
             else:
                 environment['drone_cache_rebuild'] = 'true'
@@ -509,8 +509,7 @@ def compiler_supports(compiler, version, cxx):
 # This is based on an exclude-list since we want to assume
 # new images will support caching
 def image_supports_caching(image_str, compiler_str):
-    return image_str == None or not (image_str[:19] == 'cppalliance/dronevs' or compiler_str[:6] == 's390x-')
-
+    return image_str != None and not (image_str[:19] == 'cppalliance/dronevs' or compiler_str[:6] == 's390x-')
 
 # Get list of available compiler versions in a semver range
 # - compilers_in_range('gcc >=10') -> [('gcc', '12'), ('gcc', '11'), ('gcc', '10')]


### PR DESCRIPTION
A proposed change to the caching methodology.

The cache key has been the boostorg/boost commit SHA, which changes around every 4 hours and thus invalidates the cache most of the times you attempt to use it. If a few hours have passed and there is a pull request or a commit, those will be cache misses.

The new strategy is to basically always use the cache. 

common_install.sh runs every time. "git pull" or "submodule update" only take a few seconds because they don't need to download a full git repository. b2 recompilation will be skipped.
