### PR TITLE
Ada tests

### DIFF
--- a/include/boost/url/impl/url_base.ipp
+++ b/include/boost/url/impl/url_base.ipp
@@ -1243,6 +1243,7 @@ set_encoded_path(
     // we add a "/." prefix to prevent that
     bool add_dot_segment =
         !make_absolute &&
+        !has_authority() &&
         s.starts_with("//");
 
 //------------------------------------------------

--- a/include/boost/url/impl/url_base.ipp
+++ b/include/boost/url/impl/url_base.ipp
@@ -2136,12 +2136,22 @@ set_user_impl(
         return dest + 2;
     }
     // add authority
+    bool const make_absolute =
+        !is_path_absolute() &&
+        !impl_.get(id_path).empty();
     auto dest = resize_impl(
-        id_user, 2 + n + 1, op);
+        id_user, 2 + n + 1 + make_absolute, op);
     impl_.split(id_user, 2 + n);
     dest[0] = '/';
     dest[1] = '/';
     dest[2 + n] = '@';
+    if (make_absolute)
+    {
+        impl_.split(id_pass, 1);
+        impl_.split(id_host, 0);
+        impl_.split(id_port, 0);
+        dest[3 + n] = '/';
+    }
     check_invariants();
     return dest + 2;
 }
@@ -2164,15 +2174,25 @@ set_password_impl(
         return dest + 1;
     }
     // add authority
+    bool const make_absolute =
+            !is_path_absolute() &&
+            !impl_.get(id_path).empty();
     auto const dest =
         resize_impl(
         id_user, id_host,
-        2 + 1 + n + 1, op);
+        2 + 1 + n + 1 + make_absolute, op);
     impl_.split(id_user, 2);
     dest[0] = '/';
     dest[1] = '/';
     dest[2] = ':';
     dest[2 + n + 1] = '@';
+    if (make_absolute)
+    {
+        impl_.split(id_pass, 2 + n);
+        impl_.split(id_host, 0);
+        impl_.split(id_port, 0);
+        dest[4 + n] = '/';
+    }
     check_invariants();
     return dest + 3;
 }
@@ -2185,12 +2205,22 @@ set_userinfo_impl(
 {
     // "//" {dest} "@"
     check_invariants();
+    bool const make_absolute =
+            !is_path_absolute() &&
+            !impl_.get(id_path).empty();
     auto dest = resize_impl(
-        id_user, id_host, n + 3, op);
+        id_user, id_host, n + 3 + make_absolute, op);
     impl_.split(id_user, n + 2);
     dest[0] = '/';
     dest[1] = '/';
     dest[n + 2] = '@';
+    if (make_absolute)
+    {
+        impl_.split(id_pass, 1);
+        impl_.split(id_host, 0);
+        impl_.split(id_port, 0);
+        dest[3 + n] = '/';
+    }
     check_invariants();
     return dest + 2;
 }
@@ -2209,7 +2239,6 @@ set_host_impl(
             !is_path_absolute() &&
             impl_.len(id_path) != 0;
         auto pn = impl_.len(id_path);
-        auto po = impl_.offset(id_path);
         auto dest = resize_impl(
             id_user, n + 2 + make_absolute, op);
         impl_.split(id_user, 2);
@@ -2219,7 +2248,6 @@ set_host_impl(
         impl_.split(id_path, pn + make_absolute);
         if (make_absolute)
         {
-            std::memmove(dest + n + 3, s_ + po, pn);
             dest[n + 2] = '/';
             ++impl_.decoded_[id_path];
         }
@@ -2251,14 +2279,23 @@ set_port_impl(
         check_invariants();
         return dest + 1;
     }
+    bool make_absolute =
+        !is_path_absolute() &&
+        impl_.len(id_path) != 0;
     auto dest = resize_impl(
-        id_user, 3 + n, op);
+        id_user, 3 + n + make_absolute, op);
     impl_.split(id_user, 2);
     impl_.split(id_pass, 0);
     impl_.split(id_host, 0);
     dest[0] = '/';
     dest[1] = '/';
     dest[2] = ':';
+    if (make_absolute)
+    {
+        impl_.split(id_port, n + 1);
+        dest[n + 3] = '/';
+        ++impl_.decoded_[id_path];
+    }
     check_invariants();
     return dest + 3;
 }

--- a/test/unit/url.cpp
+++ b/test/unit/url.cpp
@@ -403,6 +403,13 @@ struct url_test
             u.set_encoded_path("http:index.htm");
             BOOST_TEST_CSTR_EQ(u.encoded_path(), "http%3Aindex.htm");
         }
+        {
+            // multiple empty segments with host
+            url u = parse_uri_reference("file:///unicorn").value();
+            u.set_encoded_path("//\\/");
+            BOOST_TEST_CSTR_EQ(u, "file:////%5C/");
+            BOOST_TEST_CSTR_EQ(u.encoded_path(), "//%5C/");
+        }
 
         // set_encoded_path
         {

--- a/test/unit/url_base.cpp
+++ b/test/unit/url_base.cpp
@@ -329,7 +329,7 @@ struct url_base_test
         {
             url u;
             BOOST_TEST_NO_THROW(u = url(s1));
-            BOOST_TEST(u.set_encoded_userinfo(s2).buffer() == s3);
+            BOOST_TEST_EQ(u.set_encoded_userinfo(s2).buffer(), s3);
             BOOST_TEST_EQ(u.encoded_userinfo(), s2);
             BOOST_TEST(u.has_userinfo());
         };
@@ -619,6 +619,57 @@ struct url_base_test
                 u.set_user(
                     u.encoded_query());
             });
+
+        // path doesn't become host
+        {
+            url u("mailto:example.net");
+            BOOST_TEST_NO_THROW(u.set_encoded_user("me"));
+            BOOST_TEST_CSTR_EQ(u, "mailto://me@/example.net");
+            BOOST_TEST_NOT(u.buffer() == "mailto://me@example.net");
+            BOOST_TEST_CSTR_EQ(u.encoded_user(), "me");
+        }
+        {
+            url u("mailto:you@example.net");
+            BOOST_TEST_NO_THROW(u.set_encoded_user("me"));
+            BOOST_TEST_CSTR_EQ(u, "mailto://me@/you@example.net");
+            BOOST_TEST_NOT(u.buffer() == "mailto://me@you@example.net");
+            BOOST_TEST_CSTR_EQ(u.encoded_user(), "me");
+        }
+        {
+            url u("mailto:a@b.c");
+            BOOST_TEST_NO_THROW(u.set_encoded_password("secret"));
+            BOOST_TEST_CSTR_EQ(u, "mailto://:secret@/a@b.c");
+        }
+        {
+            url u("mailto:a@b.c");
+            BOOST_TEST_NO_THROW(u.set_encoded_userinfo("u:p"));
+            BOOST_TEST_CSTR_EQ(u, "mailto://u:p@/a@b.c");
+        }
+        {
+            url u("mailto://h/a@b.c");
+            BOOST_TEST_NO_THROW(u.set_encoded_userinfo("u:p"));
+            BOOST_TEST_CSTR_EQ(u, "mailto://u:p@h/a@b.c");
+        }
+        {
+            url u("mailto:a@b.c");
+            BOOST_TEST_NO_THROW(u.set_encoded_userinfo("u"));
+            BOOST_TEST_CSTR_EQ(u, "mailto://u@/a@b.c");
+        }
+        {
+            url u("mailto://h/a@b.c");
+            BOOST_TEST_NO_THROW(u.set_encoded_userinfo("u"));
+            BOOST_TEST_CSTR_EQ(u, "mailto://u@h/a@b.c");
+        }
+        {
+            url u("mailto:a@b.c");
+            BOOST_TEST_NO_THROW(u.set_encoded_host("host"));
+            BOOST_TEST_CSTR_EQ(u, "mailto://host/a@b.c");
+        }
+        {
+            url u("mailto:a@b.c");
+            BOOST_TEST_NO_THROW(u.set_port("80"));
+            BOOST_TEST_CSTR_EQ(u, "mailto://:80/a@b.c");
+        }
     }
 
     void

--- a/test/unit/url_base.cpp
+++ b/test/unit/url_base.cpp
@@ -23,6 +23,12 @@
     ':' 0x3a
 */
 
+#ifdef BOOST_TEST_CSTR_EQ
+#undef BOOST_TEST_CSTR_EQ
+#define BOOST_TEST_CSTR_EQ(expr1,expr2) \
+    BOOST_TEST_EQ( boost::urls::detail::to_sv(expr1), boost::urls::detail::to_sv(expr2) )
+#endif
+
 namespace boost {
 namespace urls {
 


### PR DESCRIPTION
This pull request (PR) expands upon the work done in https://github.com/boostorg/url/pull/714 by replicating all other additional tests from Ada. While the previous PR focused on replicating basic tests, this one covers all other tests that don't rely on URLs with Unicode which Boost.URL doesn't support.

As with any testing, these tests explore various corner cases, and the expected results may differ between Ada and Boost.URL. In cases where the expected results differ, the expected result in Ada is described and the expected result in Boost.URL is explicitly tested.

Through these tests, a number of bugs were uncovered and fixed in separate commits. Specifically, several url transformations were allowing the path to become the authority, thereby breaking the URL invariants. Additionally, multiple empty path segments were causing unnecessary dot segments to be included in the URL.

Another issue identified during testing was that Boost.URL wasn't maintaining the original user input when an IP address was provided to `set_encoded_host`. Instead, the internal parser converts the user input to the IP binary representation and then converts that to a new string. While not technically a bug, this behavior differs slightly from other setters.