### PR TITLE
Github Actions: remove ilammy/msvc-dev-cmd

### DIFF
--- a/.github/actions/b2_workflow/action.yml
+++ b/.github/actions/b2_workflow/action.yml
@@ -61,10 +61,6 @@ runs:
       uses: SimenB/github-actions-cpu-cores@v1
       id: cpu-cores
 
-    - name: Setup msvc dev-cmd
-      if: runner.os == 'Windows'
-      uses: ilammy/msvc-dev-cmd@v1
-
     - name: Bootstrap
       working-directory: ${{ inputs.source-dir }}
       shell: bash


### PR DESCRIPTION
@alandefreitas, a suggestion to remove the 'ilammy/msvc-dev-cmd@v1' action.     

The reasons are:

- it's not required for the CI jobs to build.
- b2 is smart enough to find a compiler anyway.
- when debugging gha runners, and jobs were failing, it actually became a question: "Is the ilammy/msvc-dev-cmd action involved in this crash, or it's not?"   (The latest evidence is, probably not. But still - fewer steps is better.)
