### PR TITLE
Allow serializing of integer zero

### DIFF
--- a/src/detail/format_args.cpp
+++ b/src/detail/format_args.cpp
@@ -373,13 +373,14 @@ measure(
         dn += measure_one(sign, cs);
         ++n;
     }
-    while (v > 0)
+    do
     {
         int d = v % 10;
         v /= 10;
         dn += measure_one('0' + static_cast<char>(d), cs);
         ++n;
     }
+    while (v > 0);
 
     std::size_t w = width;
     if (width_idx != std::size_t(-1) ||
@@ -412,13 +413,14 @@ measure(
         dn += measure_one(sign, cs);
         ++n;
     }
-    while (v != 0)
+    do
     {
         int d = v % 10;
         v /= 10;
         dn += measure_one('0' + static_cast<char>(d), cs);
         ++n;
     }
+    while (v != 0);
 
     std::size_t w = width;
     if (width_idx != std::size_t(-1) ||
@@ -457,13 +459,14 @@ format(
     {
         ++n;
     }
-    while (v > 0)
+    do
     {
         if (v >= 10)
             p *= 10;
         v /= 10;
         ++n;
     }
+    while (v > 0);
     static constexpr auto m =
         std::numeric_limits<long long int>::digits10;
     BOOST_ASSERT(n <= m + 1);
@@ -559,13 +562,14 @@ grammar::lut_chars const& cs) const
     {
         ++n;
     }
-    while (v > 0)
+    do
     {
         if (v >= 10)
             p *= 10;
         v /= 10;
         ++n;
     }
+    while (v > 0);
     static constexpr auto m =
         std::numeric_limits<unsigned long long int>::digits10;
     BOOST_ASSERT(n <= m + 1);

--- a/test/unit/format.cpp
+++ b/test/unit/format.cpp
@@ -465,6 +465,28 @@ struct format_test
             BOOST_TEST_NOT( u.has_query() );
         }
         {
+            url u = format("{}", 0);
+            BOOST_TEST_CSTR_EQ(u.buffer(), "0");
+            BOOST_TEST_NOT( u.has_authority() );
+            BOOST_TEST_NOT( u.has_userinfo() );
+            BOOST_TEST( u.encoded_host().empty() );
+            BOOST_TEST_CSTR_EQ( u.encoded_path(), "0" );
+            BOOST_TEST_NOT( u.is_path_absolute() );
+            segs_equal( u.encoded_segments(), {"0"});
+            BOOST_TEST_NOT( u.has_query() );
+        }
+        {
+            url u = format("{}", 0U);
+            BOOST_TEST_CSTR_EQ(u.buffer(), "0");
+            BOOST_TEST_NOT( u.has_authority() );
+            BOOST_TEST_NOT( u.has_userinfo() );
+            BOOST_TEST( u.encoded_host().empty() );
+            BOOST_TEST_CSTR_EQ( u.encoded_path(), "0" );
+            BOOST_TEST_NOT( u.is_path_absolute() );
+            segs_equal( u.encoded_segments(), {"0"});
+            BOOST_TEST_NOT( u.has_query() );
+        }
+        {
             url u = format("/a");
             BOOST_TEST_CSTR_EQ(u.buffer(), "/a");
             BOOST_TEST_NOT( u.has_authority() );


### PR DESCRIPTION
Fixes #758

The parsing and measuring code didn't have explicit handling for integer zero, and the while(v > 0) loop wouldn't execute.

Also add tests to cover both of these cases.