### PR TITLE
Self-hosted github actions runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,19 @@ env:
   DEFAULT_BUILD_VARIANT: debug,release
 
 jobs:
+  runner-selection:
+    # runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'boostorg' && fromJSON('[ "self-hosted", "linux", "x64", "ubuntu-latest-aws" ]') || 'ubuntu-latest' }}
+    outputs:
+      labelmatrix: ${{ steps.aws_hosted_runners.outputs.labelmatrix }}
+    steps:
+      - name: AWS Hosted Runners
+        id: aws_hosted_runners
+        uses: cppalliance/aws-hosted-runners@v1.0.0
+
   cpp-matrix:
-    runs-on: ubuntu-latest
+    needs: [runner-selection]
+    runs-on: ${{ fromJSON(needs.runner-selection.outputs.labelmatrix)['ubuntu-latest'] }}
     name: Generate Test Matrix
     outputs:
       matrix: ${{ steps.cpp-matrix.outputs.matrix }}
@@ -57,7 +68,7 @@ jobs:
           trace-commands: true
 
   build:
-    needs: cpp-matrix
+    needs: [cpp-matrix,runner-selection]
     defaults:
       run:
         shell: bash
@@ -67,7 +78,7 @@ jobs:
         include: ${{ fromJSON(needs.cpp-matrix.outputs.matrix) }}
 
     name: ${{ matrix.name }}
-    runs-on: ${{matrix.runs-on}}
+    runs-on: ${{ fromJSON(needs.runner-selection.outputs.labelmatrix)[matrix.runs-on] }}
     container: ${{matrix.container}}
     timeout-minutes: 120
 
@@ -250,13 +261,13 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
   changelog:
-    needs: cpp-matrix
+    needs: [cpp-matrix,runner-selection]
     defaults:
       run:
         shell: bash
 
     name: Changelog Summary
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJSON(needs.runner-selection.outputs.labelmatrix)['ubuntu-22.04'] }}
     timeout-minutes: 120
 
     steps:


### PR DESCRIPTION
This is the first pull request using the new runners and so it is a debug/validation phase also.

In other testing of URL there were a couple of errors on Windows.  Potential solutions are:

1. fix a bug in the URL codebase
2. Or, if you have some idea why the error happens, suggest an update to the Windows images.  I will add new packages to the Windows AMIs
3. Or, if it remains a mystery, set the runner label to 'windows-2022-no-aws' , which will cause that job to always run on a GitHub-hosted runner.