### PR TITLE
fix: url_view string_view constructor requires non-url_view_base

### DIFF
--- a/include/boost/url/url_view.hpp
+++ b/include/boost/url/url_view.hpp
@@ -204,7 +204,12 @@ public:
             std::is_convertible<
                 String,
                 core::string_view
-                    >::value>::type
+                    >::value &&
+            !std::is_convertible<
+                String*,
+                url_view_base*
+                    >::value
+            >::type
 #endif
     >
     url_view(

--- a/test/unit/url_view.cpp
+++ b/test/unit/url_view.cpp
@@ -108,6 +108,15 @@ public:
             auto const f = []( url_view ) {};
             f( "x" );
         }
+
+        // issue #756
+        {
+            url u("http://example.com");
+            auto foo = [&u](url_view uv) {
+                BOOST_TEST(uv.buffer().data() == u.buffer().data());
+            };
+            foo(u);
+        }
     }
 
     void


### PR DESCRIPTION
fix #756