### PR TITLE
build: enforce BOOST_SRC_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2019 Vinnie Falco (vinnie.falco@gmail.com)
 # Copyright (c) 2021 DMitry Arkhipov (grisumbras@gmail.com)
+# Copyright (c) 2022 Alan de Freitas (alandefreitas@gmail.com)
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -8,9 +9,11 @@
 # Official repository: https://github.com/boostorg/url
 #
 
-#######################################################
-### Project                                         ###
-#######################################################
+#-------------------------------------------------
+#
+# Project
+#
+#-------------------------------------------------
 cmake_minimum_required(VERSION 3.8)
 set(BOOST_URL_VERSION 2)
 if (BOOST_SUPERPROJECT_VERSION)
@@ -23,18 +26,22 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 endif ()
 set(__ignore__ ${CMAKE_C_COMPILER})
 
-#######################################################
-### Options                                         ###
-#######################################################
+#-------------------------------------------------
+#
+# Options
+#
+#-------------------------------------------------
 option(BOOST_URL_BUILD_TESTS "Build boost::url tests" ${BUILD_TESTING})
 option(BOOST_URL_BUILD_FUZZERS "Build boost::url fuzzers" OFF)
 option(BOOST_URL_BUILD_EXAMPLES "Build boost::url examples" ${BOOST_URL_IS_ROOT})
 option(BOOST_URL_DISABLE_THREADS "Disable threads" OFF)
 set(BOOST_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.." CACHE STRING "Boost source dir to use when running CMake from this directory")
 
-#######################################################
-### Boost modules                                   ###
-#######################################################
+#-------------------------------------------------
+#
+# Boost modules
+#
+#-------------------------------------------------
 # The boost super-project requires one explicit dependency per-line.
 set(BOOST_URL_DEPENDENCIES
         Boost::align
@@ -54,14 +61,22 @@ foreach (BOOST_URL_DEPENDENCY ${BOOST_URL_DEPENDENCIES})
         list(APPEND BOOST_URL_INCLUDE_LIBRARIES ${CMAKE_MATCH_1})
     endif ()
 endforeach ()
-set(BOOST_URL_UNIT_TEST_LIBRARIES container filesystem unordered)
-set(BOOST_URL_EXAMPLE_LIBRARIES json regex beast)
+# Conditional dependencies
+if (BOOST_URL_BUILD_TESTS)
+    set(BOOST_URL_UNIT_TEST_LIBRARIES container filesystem unordered)
+endif()
+if (BOOST_URL_BUILD_EXAMPLES)
+    set(BOOST_URL_EXAMPLE_LIBRARIES json regex beast)
+endif()
+# Complete dependency list
 set(BOOST_INCLUDE_LIBRARIES ${BOOST_URL_INCLUDE_LIBRARIES} ${BOOST_URL_UNIT_TEST_LIBRARIES} ${BOOST_URL_EXAMPLE_LIBRARIES})
 set(BOOST_EXCLUDE_LIBRARIES url)
 
-#######################################################
-### Add Boost Subdirectory                          ###
-#######################################################
+#-------------------------------------------------
+#
+# Add Boost Subdirectory
+#
+#-------------------------------------------------
 if (NOT BOOST_SUPERPROJECT_VERSION)
     set(CMAKE_FOLDER Dependencies)
     # Find absolute BOOST_SRC_DIR
@@ -98,9 +113,11 @@ if (NOT BOOST_SUPERPROJECT_VERSION)
     unset(CMAKE_FOLDER)
 endif ()
 
-#######################################################
-### Library                                         ###
-#######################################################
+#-------------------------------------------------
+#
+# Library
+#
+#-------------------------------------------------
 file(GLOB_RECURSE BOOST_URL_HEADERS CONFIGURE_DEPENDS include/boost/*.hpp include/boost/*.natvis)
 file(GLOB_RECURSE BOOST_URL_SOURCES CONFIGURE_DEPENDS src/*.cpp)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -121,9 +138,11 @@ add_library(boost_url ${BOOST_URL_HEADERS} ${BOOST_URL_SOURCES})
 add_library(Boost::url ALIAS boost_url)
 boost_url_setup_properties(boost_url)
 
-#######################################################
-### Tests                                           ###
-#######################################################
+#-------------------------------------------------
+#
+# Tests
+#
+#-------------------------------------------------
 if (BOOST_URL_BUILD_TESTS)
     if (BOOST_URL_IS_ROOT)
         include(CTest)
@@ -131,6 +150,11 @@ if (BOOST_URL_BUILD_TESTS)
     add_subdirectory(test)
 endif ()
 
+#-------------------------------------------------
+#
+# Examples
+#
+#-------------------------------------------------
 if (BOOST_URL_BUILD_EXAMPLES)
     add_subdirectory(example)
 endif ()

--- a/src/parse_query.cpp
+++ b/src/parse_query.cpp
@@ -37,7 +37,7 @@ parse_query(core::string_view s) noexcept
         return rv.error();
     return params_encoded_view(
         detail::query_ref(
-            s.data(), s.size(), rv->size()));
+            s, s.size(), rv->size()));
 }
 
 } // urls

--- a/test/unit/parse_query.cpp
+++ b/test/unit/parse_query.cpp
@@ -20,9 +20,36 @@ struct parse_query_test
     void
     testParse()
     {
-        system::result<params_encoded_view> rv;
+        {
+            system::result<params_encoded_view> rv;
+            rv = parse_query( "key=value" );
+            BOOST_TEST( ! rv.has_error() );
+            BOOST_TEST( rv->size() == 1 );
+            BOOST_TEST( rv->begin()->key == "key" );
+            BOOST_TEST( rv->begin()->value == "value" );
+        }
 
-        rv = parse_query( "key=value" );
+        // issue #757
+        {
+            auto data = std::string("abc=def&ghi=jkl&mno=pqr");
+            core::string_view view( data.data(), data.size() - 2 );
+            system::result<params_encoded_view> rv;
+            rv = parse_query( view );
+            BOOST_TEST( ! rv.has_error() );
+            params_encoded_view params = *rv;
+            BOOST_TEST( params.size() == 3 );
+            auto it = params.begin();
+            BOOST_TEST_EQ( it->key, "abc" );
+            BOOST_TEST_EQ( it->value, "def" );
+            ++it;
+            BOOST_TEST_EQ( it->key, "ghi" );
+            BOOST_TEST_EQ( it->value, "jkl" );
+            ++it;
+            BOOST_TEST_EQ( it->key, "mno" );
+            BOOST_TEST_EQ( it->value, "p" );
+            ++it;
+            BOOST_TEST( it == params.end() );
+        }
     }
 
     void


### PR DESCRIPTION
Although c518dbaa already included BOOST_SRC_DIR and removed support for standalone installation, this PR enforces that appropriate BOOST_INCLUDE_LIBRARIES are set according to the build options.

fix #679