### PR TITLE
fix: IP-literal can be IPv6addrz

### DIFF
--- a/include/boost/url/rfc/detail/ipv6_addrz_rule.hpp
+++ b/include/boost/url/rfc/detail/ipv6_addrz_rule.hpp
@@ -1,6 +1,5 @@
 //
-// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
-// Copyright (c) 2022 Alan de Freitas (vinnie dot falco at gmail dot com)
+// Copyright (c) 2023 Alan de Freitas (alandefreitas@gmail.com)
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -8,50 +7,47 @@
 // Official repository: https://github.com/boostorg/url
 //
 
-#ifndef BOOST_URL_RFC_DETAIL_IP_LITERAL_RULE_HPP
-#define BOOST_URL_RFC_DETAIL_IP_LITERAL_RULE_HPP
+#ifndef BOOST_URL_RFC_DETAIL_IPV6ADDRZ_RULE_HPP
+#define BOOST_URL_RFC_DETAIL_IPV6ADDRZ_RULE_HPP
 
-#include <boost/url/detail/config.hpp>
-#include <boost/url/ipv6_address.hpp>
 #include <boost/url/error_types.hpp>
+#include <boost/url/ipv6_address.hpp>
+#include <boost/url/pct_string_view.hpp>
 #include <boost/core/detail/string_view.hpp>
 
 namespace boost {
 namespace urls {
 namespace detail {
 
-/** Rule for IP-literal
+/** Rule for IPvFuture
 
     @par BNF
     @code
-    IP-literal = "[" ( IPv6address / IPv6addrz / IPvFuture  ) "]"
+    IPv6addrz = IPv6address "%25" ZoneID
+    ZoneID = 1*( unreserved / pct-encoded )
     @endcode
 
     @par Specification
     @li <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2"
         >3.2.2. Host (rfc3986)</a>
-
-    @see
-        @ref ipv6_address.
 */
-struct ip_literal_rule_t
+struct ipv6_addrz_rule_t
 {
     struct value_type
     {
-        bool is_ipv6 = false;
         ipv6_address ipv6;
-        core::string_view ipvfuture;
+        pct_string_view zone_id;
     };
 
     auto
     parse(
         char const*& it,
-        char const* end
+        char const* const end
             ) const noexcept ->
         system::result<value_type>;
 };
 
-constexpr ip_literal_rule_t ip_literal_rule{};
+constexpr ipv6_addrz_rule_t ipv6_addrz_rule{};
 
 } // detail
 } // urls

--- a/include/boost/url/url_view_base.hpp
+++ b/include/boost/url/url_view_base.hpp
@@ -1368,6 +1368,88 @@ public:
     pct_string_view
     encoded_host_name() const noexcept;
 
+    /** Return the IPv6 Zone ID
+
+        If the host type is @ref host_type::ipv6,
+        this function returns the Zone ID as
+        a string. Otherwise an empty string is returned.
+        Any percent-escapes in the string are
+        decoded first.
+
+        @par Example
+        @code
+        assert( url_view( "http://[fe80::1%25eth0]/" ).zone_id() == "eth0" );
+        @endcode
+
+        @par Complexity
+        Linear in `this->encoded_zone_id().size()`.
+
+        @par Exception Safety
+        Calls to allocate may throw.
+
+        @par BNF
+        @code
+        host        = IP-literal / IPv4address / reg-name
+
+        IP-literal = "[" ( IPv6address / IPv6addrz / IPvFuture  ) "]"
+
+        ZoneID = 1*( unreserved / pct-encoded )
+
+        IPv6addrz = IPv6address "%25" ZoneID
+        @endcode
+
+        @par Specification
+        @li <a href="https://datatracker.ietf.org/doc/html/rfc6874"
+            >Representing IPv6 Zone Identifiers in Address Literals and Uniform Resource Identifiers</a>
+    */
+    template<BOOST_URL_STRTOK_TPARAM>
+    BOOST_URL_STRTOK_RETURN
+    zone_id(
+        BOOST_URL_STRTOK_ARG(token)) const
+    {
+        encoding_opts opt;
+        opt.space_as_plus = false;
+        return encoded_zone_id().decode(
+            opt, std::move(token));
+    }
+
+    /** Return the IPv6 Zone ID
+
+        If the host type is @ref host_type::ipv6,
+        this function returns the Zone ID as
+        a string. Otherwise an empty string is returned.
+        The returned string may contain
+        percent escapes.
+
+        @par Example
+        @code
+        assert( url_view( "http://[fe80::1%25eth0]/" ).encoded_zone_id() == "eth0" );
+        @endcode
+
+        @par Complexity
+        Constant.
+
+        @par Exception Safety
+        Throws nothing.
+
+        @par BNF
+        @code
+        host        = IP-literal / IPv4address / reg-name
+
+        IP-literal = "[" ( IPv6address / IPv6addrz / IPvFuture  ) "]"
+
+        ZoneID = 1*( unreserved / pct-encoded )
+
+        IPv6addrz = IPv6address "%25" ZoneID
+        @endcode
+
+        @par Specification
+        @li <a href="https://datatracker.ietf.org/doc/html/rfc6874"
+            >Representing IPv6 Zone Identifiers in Address Literals and Uniform Resource Identifiers</a>
+    */
+    pct_string_view
+    encoded_zone_id() const noexcept;
+
     //--------------------------------------------
     //
     // Port

--- a/src/rfc/detail/ip_literal_rule.cpp
+++ b/src/rfc/detail/ip_literal_rule.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+// Copyright (c) 2022 Alan de Freitas (alandefreitas@gmail.com)
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -13,11 +14,10 @@
 #include <boost/url/detail/config.hpp>
 #include <boost/url/rfc/ipv6_address_rule.hpp>
 #include <boost/url/rfc/detail/ip_literal_rule.hpp>
-#include <boost/url/ipv6_address.hpp>
+#include <boost/url/rfc/detail/ipv6_addrz_rule.hpp>
 #include <boost/url/grammar/delim_rule.hpp>
 #include <boost/url/grammar/parse.hpp>
 #include <boost/url/grammar/tuple_rule.hpp>
-#include <boost/url/grammar/parse.hpp>
 #include <boost/url/rfc/detail/ipvfuture_rule.hpp>
 
 namespace boost {
@@ -50,6 +50,7 @@ parse(
     if(*it != 'v')
     {
         // IPv6address
+        auto it0 = it;
         auto rv = grammar::parse(
             it, end,
             grammar::tuple_rule(
@@ -57,7 +58,21 @@ parse(
                 grammar::squelch(
                     grammar::delim_rule(']'))));
         if(! rv)
-            return rv.error();
+        {
+            // IPv6addrz
+            it = it0;
+            auto rv2 = grammar::parse(
+                it, end,
+                grammar::tuple_rule(
+                    ipv6_addrz_rule,
+                    grammar::squelch(
+                        grammar::delim_rule(']'))));
+            if(! rv2)
+                return rv2.error();
+            t.ipv6 = rv2->ipv6;
+            t.is_ipv6 = true;
+            return t;
+        }
         t.ipv6 = *rv;
         t.is_ipv6 = true;
         return t;

--- a/src/rfc/detail/ipv6_addrz_rule.cpp
+++ b/src/rfc/detail/ipv6_addrz_rule.cpp
@@ -1,0 +1,74 @@
+//
+// Copyright (c) 2023 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/url
+//
+
+#ifndef BOOST_URL_RFC_DETAIL_IMPL_IPV6_ADDRZ_RULE_IPP
+#define BOOST_URL_RFC_DETAIL_IMPL_IPV6_ADDRZ_RULE_IPP
+
+#include <boost/url/detail/config.hpp>
+#include <boost/url/grammar/parse.hpp>
+#include <boost/url/rfc/detail/ipv6_addrz_rule.hpp>
+#include <boost/url/rfc/ipv6_address_rule.hpp>
+#include <boost/url/rfc/unreserved_chars.hpp>
+#include <boost/url/rfc/pct_encoded_rule.hpp>
+
+namespace boost {
+namespace urls {
+namespace detail {
+
+auto
+ipv6_addrz_rule_t::
+parse(
+    char const*& it,
+    char const* const end
+        ) const noexcept ->
+    system::result<value_type>
+{
+    value_type t;
+    auto rv1 = grammar::parse(
+        it, end, ipv6_address_rule);
+    if (! rv1)
+        return rv1.error();
+    t.ipv6 = *rv1;
+
+    // "%25"
+    auto it0 = it;
+    if (end - it < 3 ||
+        *it != '%' ||
+        *(it + 1) != '2' ||
+        *(it + 2) != '5')
+    {
+        BOOST_URL_RETURN_EC(
+            grammar::error::invalid);
+    }
+    it += 3;
+
+    // ZoneID = 1*( unreserved / pct-encoded )
+    // Parse as many (unreserved / pct-encoded)
+    // as available
+    auto rv2 = grammar::parse(
+            it, end,
+            pct_encoded_rule(unreserved_chars));
+    if(!rv2 || rv2->empty())
+    {
+        it = it0;
+        BOOST_URL_RETURN_EC(
+            grammar::error::invalid);
+    }
+    else
+    {
+        t.zone_id = *rv2;
+    }
+    return t;
+}
+
+} // detail
+} // urls
+} // boost
+
+#endif

--- a/src/url_view_base.cpp
+++ b/src/url_view_base.cpp
@@ -419,6 +419,24 @@ encoded_host_name() const noexcept
         pi_->decoded_[id_host]);
 }
 
+pct_string_view
+url_view_base::
+encoded_zone_id() const noexcept
+{
+    if(pi_->host_type_ !=
+        urls::host_type::ipv6)
+        return {};
+    core::string_view s = pi_->get(id_host);
+    BOOST_ASSERT(s.front() == '[');
+    BOOST_ASSERT(s.back() == ']');
+    s = s.substr(1, s.size() - 2);
+    auto pos = s.find("%25");
+    if (pos == core::string_view::npos)
+        return {};
+    s.remove_prefix(pos + 3);
+    return *make_pct_string_view(s);
+}
+
 //------------------------------------------------
 
 bool

--- a/test/unit/ipv6_address.cpp
+++ b/test/unit/ipv6_address.cpp
@@ -178,8 +178,8 @@ public:
     void
     good(core::string_view s)
     {
-        BOOST_TEST(ipv6_address(
-            s).to_string() == s);
+        BOOST_TEST_EQ(ipv6_address(
+            s).to_string(), s);
     }
 
     static

--- a/test/unit/url_view.cpp
+++ b/test/unit/url_view.cpp
@@ -600,6 +600,24 @@ public:
             BOOST_TEST(u.authority().encoded_host_and_port() ==
                 "xyz:99999");
         }
+        {
+            // zone_id
+            auto check = [](core::string_view u0, core::string_view zone_id)
+            {
+                auto ru = parse_uri(u0);
+                BOOST_TEST(ru.has_value());
+                auto const& u = *ru;
+                BOOST_TEST_EQ(u.encoded_zone_id(), zone_id);
+                pct_string_view ps{zone_id};
+                BOOST_TEST_EQ(u.zone_id(), ps.decode());
+            };
+            check("http://[fe80::1%25eth0]/", "eth0");
+            check("http://[2001:db8::1%25eth1]/index.html", "eth1");
+            check("ftp://[fe80::2%25wlan0]:8080/files/", "wlan0");
+            check("ftp://[fe80::2]:8080/files/", "");
+            check("ftp://a.com/files/", "");
+            BOOST_TEST_NOT(parse_uri("http://[fe80::1%25]/").has_value());
+        }
     }
 
     void


### PR DESCRIPTION
This commit changes the IP-literal rule to also accept IPv6addrz as a valid ipv6 host type. IPv6addrz includes a ZoneID at the end, delimited by an encoded "%25". The ipv6_address class is unmodified, as the mapping from the ZoneID to a std::uint32_t is dependent on the application context. The original ZoneID can be obtained from the url_view.

fix #711