### PR TITLE
ci: enable drone caching

### DIFF
--- a/.drone/drone.sh
+++ b/.drone/drone.sh
@@ -105,9 +105,6 @@ common_install() {
     fi
   fi
 
-  # !!! See: https://github.com/boostorg/url/issues/760
-  boost_cache_hit=false
-
   # Setup boost
   # If no cache: Clone, patch with boost-ci/ci, run common_install, and cache the result
   # If cache hit: Copy boost from cache, patch $SELF, and look for new dependencies with depinst


### PR DESCRIPTION
Drone caching had been disabled in 20ab896f because of an issue in boostorg/boost-ci. Since then, this issue has been fixed in boostorg/boost-ci PR #213.

closes #760