### PR TITLE
docs: fix reference issues

### DIFF
--- a/doc/qbk/0.main.qbk
+++ b/doc/qbk/0.main.qbk
@@ -107,7 +107,6 @@
 [def __url_base__               [link url.ref.boost__urls__url_base `url_base`]]
 [def __url_view__               [link url.ref.boost__urls__url_view `url_view`]]
 [def __url_view_base__          [link url.ref.boost__urls__url_view_base `url_view_base`]]
-[def __variant__                [link url.ref.boost__urls__variant `variant`]]
 
 [def __dec_octet_rule__         [link url.ref.boost__urls__grammar__dec_octet_rule `dec_octet_rule`]]
 [def __delim_rule__             [link url.ref.boost__urls__grammar__delim_rule `delim_rule`]]

--- a/doc/qbk/quickref.xml
+++ b/doc/qbk/quickref.xml
@@ -126,7 +126,6 @@
           <member><link linkend="url.ref.boost__urls__string_view"><emphasis role="red">string_view</emphasis></link></member>
           <member><link linkend="url.ref.boost__urls__system_category"><emphasis role="red">system_category</emphasis></link></member>
           <member><link linkend="url.ref.boost__urls__system_error"><emphasis role="red">system_error</emphasis></link></member>
-          <member><link linkend="url.ref.boost__urls__variant"><emphasis role="red">variant</emphasis></link></member>
         </simplelist>
 
       </entry>

--- a/include/boost/url/authority_view.hpp
+++ b/include/boost/url/authority_view.hpp
@@ -31,7 +31,7 @@ namespace urls {
     strings constructed from a parsed, external
     character buffer whose storage is managed
     by the caller. That is, it acts like a
-    @ref core::string_view in terms of ownership.
+    `core::string_view` in terms of ownership.
     The caller is responsible for ensuring
     that the lifetime of the underlying
     character buffer extends until it is no

--- a/include/boost/url/decode_view.hpp
+++ b/include/boost/url/decode_view.hpp
@@ -72,7 +72,7 @@ make_decode_view(
     @par Operators
     The following operators are supported between
     @ref decode_view and any object that is convertible
-    to @ref core::string_view
+    to `core::string_view`
 
     @code
     bool operator==( decode_view, decode_view ) noexcept;

--- a/include/boost/url/error_types.hpp
+++ b/include/boost/url/error_types.hpp
@@ -26,7 +26,7 @@ namespace error_types {
 
     @note This alias is no longer supported and
     should not be used in new code. Please use
-    `core::string_view` instead.
+    `system::error_category` instead.
 
     This alias is included for backwards
     compatibility with earlier versions of the
@@ -48,7 +48,7 @@ using error_category
 
     @note This alias is no longer supported and
     should not be used in new code. Please use
-    `core::string_view` instead.
+    `system::error_code` instead.
 
     This alias is included for backwards
     compatibility with earlier versions of the
@@ -70,7 +70,7 @@ using error_code
 
     @note This alias is no longer supported and
     should not be used in new code. Please use
-    `core::string_view` instead.
+    `system::error_condition` instead.
 
     This alias is included for backwards
     compatibility with earlier versions of the
@@ -92,7 +92,7 @@ using error_condition
 
     @note This alias is no longer supported and
     should not be used in new code. Please use
-    `core::string_view` instead.
+    `system::system_error` instead.
 
     This alias is included for backwards
     compatibility with earlier versions of the
@@ -189,7 +189,7 @@ namespace errc = boost::system::errc;
 
     @note This alias is no longer supported and
     should not be used in new code. Please use
-    `core::string_view` instead.
+    `system::result` instead.
 
     This alias is included for backwards
     compatibility with earlier versions of the

--- a/include/boost/url/grammar/delim_rule.hpp
+++ b/include/boost/url/grammar/delim_rule.hpp
@@ -26,7 +26,7 @@ namespace grammar {
     This matches the specified character.
     The value is a reference to the character
     in the underlying buffer, expressed as a
-    @ref core::string_view. The function @ref squelch
+    `core::string_view`. The function @ref squelch
     may be used to turn this into `void` instead.
     If there is no more input, the error code
     @ref error::need_more is returned.
@@ -94,7 +94,7 @@ delim_rule( char ch ) noexcept
     belongs to the specified character set.
     The value is a reference to the character
     in the underlying buffer, expressed as a
-    @ref core::string_view. The function @ref squelch
+    `core::string_view`. The function @ref squelch
     may be used to turn this into `void` instead.
     If there is no more input, the error code
     @ref error::need_more is returned.

--- a/include/boost/url/grammar/variant_rule.hpp
+++ b/include/boost/url/grammar/variant_rule.hpp
@@ -65,8 +65,7 @@ namespace grammar {
         @ref delim_rule,
         @ref parse,
         @ref origin_form_rule,
-        @ref url_view,
-        @ref variant.
+        @ref url_view.
 */
 #ifdef BOOST_URL_DOCS
 template<class... Rules>

--- a/include/boost/url/optional.hpp
+++ b/include/boost/url/optional.hpp
@@ -20,7 +20,7 @@ namespace urls {
 
     @note This alias is no longer supported and
     should not be used in new code. Please use
-    `core::string_view` instead.
+    `boost::optional` instead.
 
     This alias is included for backwards
     compatibility with earlier versions of the

--- a/include/boost/url/param.hpp
+++ b/include/boost/url/param.hpp
@@ -268,7 +268,7 @@ struct param
         Calls to allocate may throw.
 
         @tparam OptionalString An optional string
-        type, such as @ref core::string_view,
+        type, such as `core::string_view`,
         `std::nullptr`, @ref no_value_t, or
         `optional<core::string_view>`.
 
@@ -484,7 +484,7 @@ struct param_view
         Throws nothing.
 
         @tparam OptionalString An optional string
-        type, such as @ref core::string_view,
+        type, such as `core::string_view`,
         `std::nullptr`, @ref no_value_t, or
         `optional<core::string_view>`.
 
@@ -766,7 +766,7 @@ struct param_pct_view
         `key` or `value` contains an invalid percent-encoding.
 
         @tparam OptionalString An optional
-        @ref core::string_view type, such as
+        `core::string_view` type, such as
         `boost::optional<core::string_view>` or
         `std::optional<core::string_view>`.
 

--- a/include/boost/url/pct_string_view.hpp
+++ b/include/boost/url/pct_string_view.hpp
@@ -47,7 +47,7 @@ ref(pct_string_view& s) noexcept;
 /** A reference to a valid percent-encoded string
 
     Objects of this type behave like a
-    @ref core::string_view and have the same interface,
+    `core::string_view` and have the same interface,
     but offer an additional invariant: they can
     only be constructed from strings containing
     valid percent-escapes.
@@ -59,7 +59,7 @@ ref(pct_string_view& s) noexcept;
     @par Operators
     The following operators are supported between
     @ref pct_string_view and any object that is
-    convertible to @ref core::string_view
+    convertible to `core::string_view`
 
     @code
     bool operator==( pct_string_view, pct_string_view ) noexcept;
@@ -159,7 +159,7 @@ public:
         @throw system_error
         The string contains an invalid percent encoding.
 
-        @tparam String A type convertible to @ref core::string_view
+        @tparam String A type convertible to `core::string_view`
 
         @param s The string to construct from.
     */

--- a/include/boost/url/url.hpp
+++ b/include/boost/url/url.hpp
@@ -471,7 +471,7 @@ public:
     /// @copydoc url_base::set_encoded_query
     url& set_encoded_query(pct_string_view s) { url_base::set_encoded_query(s); return *this; }
     /// @copydoc url_base::set_params
-    url& set_params(std::initializer_list<param_view> s) { url_base::set_params(s); return *this; }
+    url& set_params(std::initializer_list<param_view> ps) { url_base::set_params(ps); return *this; }
     /// @copydoc url_base::set_encoded_params
     url& set_encoded_params(std::initializer_list< param_pct_view > ps) { url_base::set_encoded_params(ps); return *this; }
     /// @copydoc url_base::remove_query

--- a/include/boost/url/url_base.hpp
+++ b/include/boost/url/url_base.hpp
@@ -2694,7 +2694,7 @@ public:
 
         If an error occurs, the contents of
         this URL are unspecified and a @ref result
-        with an @ref system::error_code is returned.
+        with an `system::error_code` is returned.
 
         @par Example
         @code

--- a/include/boost/url/url_view.hpp
+++ b/include/boost/url/url_view.hpp
@@ -24,7 +24,7 @@ namespace urls {
     strings constructed from a parsed, external
     character buffer whose storage is managed
     by the caller. That is, it acts like a
-    @ref core::string_view in terms of ownership.
+    `core::string_view` in terms of ownership.
     The caller is responsible for ensuring
     that the lifetime of the underlying
     character buffer extends until it is no


### PR DESCRIPTION
This PR fixes issues that were causing warnings when generating the reference with docca. Along with other fixes recently pushed in `boostorg/docca`, it should completely fix all problems related to the reference.

- 2e0c3eec) docs: update javadoc deprecated references: This commit fixes a mistake where the javadoc for many deprecated aliases included references to the deprecated alias `boost::core::string_view` instead of the correct deprecated aliases `boost::optional`, `system::error_category`, `system::error_code`, `system::error_condition`, `system::system_error`, and `system::result`.
- 3ded066a) docs: remove references to variant: This commit removes links and references to 'variant' in both the .qbk and .xml files under the documentation directory. These references were removed as the `variant` alias has been deprecated in 96438f68.
- 0717afec) docs: replace @ref prefix with backtick for references: This change alters the way we reference external symbols within the documentation comments. These direct references became invalid since 96438f68.
- aba72cb5) docs: refactor variable name in url::set_params: Renamed method parameter `s` to `ps` in `url::set_params` to ensure it matches the documentation copied from `url_base::set_params`.