### PR TITLE
test: fix CMake issue with unusual compilers

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,7 @@ if(NOT TARGET boost_url_all_tests)
 endif()
 
 # Replicate error flags from Jamfile
+set(BOOST_URL_TEST_FLAGS " ")
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION_MAJOR EQUAL 7)
     set(BOOST_URL_TEST_FLAGS "-Wall -Werror -Wno-unused-but-set-variable -Wno-maybe-uninitialized")
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")


### PR DESCRIPTION
I am building Boost using CMake along with the Intel C++ compiler. I was seeing this error at configuration time:
```
-- Performing Test BOOST_STACKTRACE_HAS_WINDBG - Failed
-- Performing Test BOOST_STACKTRACE_HAS_WINDBG_CACHED
-- Performing Test BOOST_STACKTRACE_HAS_WINDBG_CACHED - Failed
-- Boost.Stacktrace: noop ON, backtrace OFF, addr2line ON, basic ON, windbg OFF, windbg_cached OFF
-- Boost.Thread: threading API is pthread
CMake Error at libs/url/test/unit/CMakeLists.txt:19 (set_source_files_properties):
  set_source_files_properties called with incorrect number of arguments.


CMake Error at libs/url/test/limits/CMakeLists.txt:19 (set_source_files_properties):
  set_source_files_properties called with incorrect number of arguments.


-- Configuring incomplete, errors occurred!
See also "/tmp/boost-build/CMakeFiles/CMakeOutput.log".
See also "/tmp/boost-build/CMakeFiles/CMakeError.log".
```

The problem is in the `Replicate error flags from Jamfile` section in `url/test/CMakeLists.txt`. My compiler has a `CMAKE_CXX_COMPILER_ID` value of `Intel`. This is not in the list of cases handled in the CMake code, so `BOOST_URL_TEST_FLAGS` remains unset. This causes the aforementioned `set_source_files_properties()` calls to not receive the arguments they need.

This change is one way of fixing the issue. It gets the build working again for me.