### PR TITLE
CML Cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,12 @@ set(__ignore__ ${CMAKE_C_COMPILER})
 # Options
 #
 #-------------------------------------------------
-option(BOOST_URL_BUILD_TESTS "Build boost::url tests" ${BUILD_TESTING})
+if(BOOST_URL_IS_ROOT OR BOOST_SUPERPROJECT_VERSION)
+  option(BOOST_URL_BUILD_TESTS "Build boost::url tests" ${BUILD_TESTING})
+else()
+  option(BOOST_URL_BUILD_TESTS "Build boost::url tests" OFF)
+endif()
+
 option(BOOST_URL_BUILD_FUZZERS "Build boost::url fuzzers" OFF)
 option(BOOST_URL_BUILD_EXAMPLES "Build boost::url examples" ${BOOST_URL_IS_ROOT})
 option(BOOST_URL_DISABLE_THREADS "Disable threads" OFF)
@@ -77,7 +82,7 @@ set(BOOST_EXCLUDE_LIBRARIES url)
 # Add Boost Subdirectory
 #
 #-------------------------------------------------
-if (NOT BOOST_SUPERPROJECT_VERSION)
+if (BOOST_URL_IS_ROOT)
     set(CMAKE_FOLDER Dependencies)
     # Find absolute BOOST_SRC_DIR
     if (NOT IS_ABSOLUTE ${BOOST_SRC_DIR})

--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -14,8 +14,37 @@ set(__ignore__ ${CMAKE_C_FLAGS})
 if(BOOST_CI_INSTALL_TEST)
     find_package(Boost CONFIG REQUIRED COMPONENTS url)
 else()
-    set(BOOST_URL_BUILD_TESTS OFF CACHE BOOL "Build the tests." FORCE)
     add_subdirectory(../.. boostorg/url)
+
+    set(deps
+        # Primary dependencies
+
+        align
+        assert
+        config
+        core
+        mp11
+        optional
+        static_assert
+        system
+        throw_exception
+        type_traits
+        variant2
+
+        # Secondary dependencies
+
+        detail
+        move
+        predef
+        utility
+        winapi
+        preprocessor
+        io
+    )
+
+  foreach(dep IN LISTS deps)
+      add_subdirectory(../../../${dep} boostorg/${dep} EXCLUDE_FROM_ALL)
+  endforeach()
 endif()
 
 add_executable(main main.cpp)


### PR DESCRIPTION
URL is problematic to use a subdirectory for both users and fellow devs.

This PR brings URL in line with how Boost libraries should behave both in terms of being used as a subdirectory of the superproject and being used as a subdirectory without the entire superproject.