### PR TITLE
CMake CI Cleanup

### DIFF
--- a/test/cmake_test/main.cpp
+++ b/test/cmake_test/main.cpp
@@ -5,11 +5,11 @@
 // https://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/url/url.hpp>
-#include <cassert>
+#include <boost/url.hpp>
 
-int main()
-{
-    assert(sizeof(boost::urls::url) > 0);
-    return 0;
+int main() {
+  boost::urls::ipv4_address ip_addr({127, 0, 0, 1});
+  if (ip_addr.to_bytes().size() != 4) {
+    throw;
+  }
 }


### PR DESCRIPTION
URL's `find_package()` CMake test doesn't actually invoke any methods defined in the found DLL for Windows platforms with `BUILD_SHARED_LIBS`.

This PR updates the test to use components of URL with out-of-line definitions which now triggers an expected CI failure.

The fix is somewhat straight-forward, just updating he `$GITHUB_PATH` in any step before the Find Package one in the ci.yml.