### PR TITLE
ci: test all Boost workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       matrix: ${{ steps.cpp-matrix.outputs.matrix }}
     steps:
       - name: Generate Test Matrix
-        uses: alandefreitas/cpp-actions/cpp-matrix@v1.5.0
+        uses: alandefreitas/cpp-actions/cpp-matrix@v1.6.1
         id: cpp-matrix
         with:
           compilers: |
@@ -93,20 +93,20 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup C++
-        uses: alandefreitas/cpp-actions/setup-cpp@v1.5.0
+        uses: alandefreitas/cpp-actions/setup-cpp@v1.6.1
         id: setup-cpp
         with:
           compiler: ${{ matrix.compiler }}
-          version: ${{ matrix.version }}
+          version: ${{ (matrix.subrange-policy == 'one-per-major' && matrix.major) || matrix.version }}
 
       - name: Install packages
-        uses: alandefreitas/cpp-actions/package-install@v1.5.0
+        uses: alandefreitas/cpp-actions/package-install@v1.6.1
         id: package-install
         with:
           apt-get: ${{ matrix.install }}
 
       - name: Clone Boost
-        uses: alandefreitas/cpp-actions/boost-clone@v1.5.0
+        uses: alandefreitas/cpp-actions/boost-clone@v1.6.1
         id: boost-clone
         with:
           branch: ${{ (github.ref_name == 'master' && github.ref_name) || 'develop' }}
@@ -158,8 +158,9 @@ jobs:
           restore-keys: | 
             corpus-
 
+      # Run cmake to build Boost.URL with the Boost super-project as PROJECT_ROOT
       - name: Boost CMake Workflow
-        uses: alandefreitas/cpp-actions/cmake-workflow@v1.5.0
+        uses: alandefreitas/cpp-actions/cmake-workflow@v1.6.1
         with:
           source-dir: ../boost-root
           build-dir: __build_cmake_test__
@@ -180,12 +181,91 @@ jobs:
           package: false
           package-artifact: false
           ref-source-dir: ../boost-root/libs/url
+          trace-commands: ${{ env.ACTIONS_STEP_DEBUG == 'true' }}
 
-      - name: Subdirectory Integration Workflow
-        uses: alandefreitas/cpp-actions/cmake-workflow@v1.5.0
+      - name: Set shared library paths
+        if: startsWith(matrix.runs-on, 'windows') && matrix.shared
+        run: |
+          echo "$GITHUB_WORKSPACE/.local/bin" >> $GITHUB_PATH
+          ls -la $GITHUB_WORKSPACE/.local/bin
+
+      # Run cmake to build a project that finds Boost as a package and
+      # url as a COMPONENT of this package.
+      - name: Boost Find Package Integration Workflow
+        uses: alandefreitas/cpp-actions/cmake-workflow@v1.6.1
+        if: ${{ matrix.is-latest || matrix.is-earliest }}
         with:
           source-dir: ../boost-root/libs/${{ steps.patch.outputs.module }}/test/cmake_test
-          build-dir: __build_cmake_subdir_test__
+          build-dir: __build_cmake_boost_install_test__
+          generator: ${{ matrix.generator }}
+          build-type: ${{ matrix.build-type }}
+          cxxstd: ${{ matrix.latest-cxxstd }}
+          cc: ${{ steps.setup-cpp.outputs.cc || matrix.cc }}
+          ccflags: ${{ matrix.ccflags }}
+          cxx: ${{ steps.setup-cpp.outputs.cxx || matrix.cxx }}
+          cxxflags: ${{ matrix.cxxflags }}
+          shared: ${{ matrix.shared }}
+          cmake-version: '*'
+          install: false
+          extra-args: -D BOOST_CI_INSTALL_TEST=ON -D CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/.local
+          package: false
+          package-artifact: false
+          ref-source-dir: ../boost-root/libs/url/test/cmake_test
+          trace-commands: ${{ env.ACTIONS_STEP_DEBUG == 'true' }}
+
+      # Run cmake to build a project that finds Boost.URL as a `boost_url` package
+      - name: Boost.URL Find Package Integration Workflow
+        uses: alandefreitas/cpp-actions/cmake-workflow@v1.6.1
+        if: ${{ matrix.is-latest || matrix.is-earliest }}
+        with:
+          source-dir: ../boost-root/libs/${{ steps.patch.outputs.module }}/test/cmake_test
+          build-dir: __build_cmake_url_install_test__
+          generator: ${{ matrix.generator }}
+          build-type: ${{ matrix.build-type }}
+          cxxstd: ${{ matrix.latest-cxxstd }}
+          cc: ${{ steps.setup-cpp.outputs.cc || matrix.cc }}
+          ccflags: ${{ matrix.ccflags }}
+          cxx: ${{ steps.setup-cpp.outputs.cxx || matrix.cxx }}
+          cxxflags: ${{ matrix.cxxflags }}
+          shared: ${{ matrix.shared }}
+          cmake-version: '*'
+          install: false
+          extra-args: -D BOOST_CI_INSTALL_MODULE_TEST=ON -D CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/.local
+          package: false
+          package-artifact: false
+          ref-source-dir: ../boost-root/libs/url/test/cmake_test
+          trace-commands: ${{ env.ACTIONS_STEP_DEBUG == 'true' }}
+
+      # Run cmake to build a project that adds the Boost super-project as subdirectory
+      # defining BOOST_INCLUDE_LIBRARIES to url
+      - name: Boost as Subdirectory Integration Workflow
+        uses: alandefreitas/cpp-actions/cmake-workflow@v1.6.1
+        if: ${{ matrix.is-latest || matrix.is-earliest }}
+        with:
+          source-dir: ../boost-root/libs/${{ steps.patch.outputs.module }}/test/cmake_test
+          build-dir: __build_cmake_boost_subdir_test__
+          generator: ${{ matrix.generator }}
+          build-type: ${{ matrix.build_type }}
+          cxxstd: ${{ matrix.latest-cxxstd }}
+          cc: ${{ steps.setup-cpp.outputs.cc || matrix.cc }}
+          ccflags: ${{ matrix.ccflags }}
+          cxx: ${{ steps.setup-cpp.outputs.cxx || matrix.cxx }}
+          cxxflags: ${{ matrix.cxxflags }}
+          shared: ${{ matrix.shared }}
+          cmake-version: '>=3.11'
+          install: false
+          extra-args: -D BOOST_CI_BOOST_SUBDIR_TEST=ON
+          ref-source-dir: ../boost-root/libs/url/test/cmake_test
+          trace-commands: ${{ env.ACTIONS_STEP_DEBUG == 'true' }}
+
+      # Run cmake to build a project that adds the Boost.URL as subdirectory
+      # All other transitive dependencies are directly added as subdirectories
+      - name: Boost.URL as Subdirectory Integration Workflow
+        uses: alandefreitas/cpp-actions/cmake-workflow@v1.6.1
+        if: ${{ matrix.is-latest || matrix.is-earliest }}
+        with:
+          source-dir: ../boost-root/libs/${{ steps.patch.outputs.module }}/test/cmake_test
+          build-dir: __build_cmake_url_subdir_test__
           generator: ${{ matrix.generator }}
           build-type: ${{ matrix.build_type }}
           cxxstd: ${{ matrix.latest-cxxstd }}
@@ -196,30 +276,14 @@ jobs:
           shared: ${{ matrix.shared }}
           install: false
           cmake-version: '>=3.11'
-          extra-args: -D BOOST_CI_INSTALL_TEST=OFF
+          extra-args: -D BOOST_CI_URL_SUBDIR_TEST=ON
           ref-source-dir: ../boost-root/libs/url/test/cmake_test
+          trace-commands: ${{ env.ACTIONS_STEP_DEBUG == 'true' }}
 
-      - name: Find Package Integration Workflow
-        uses: alandefreitas/cpp-actions/cmake-workflow@v1.5.0
-        with:
-          source-dir: ../boost-root/libs/${{ steps.patch.outputs.module }}/test/cmake_test
-          build-dir: __build_cmake_install_test__
-          generator: ${{ matrix.generator }}
-          build-type: ${{ matrix.build-type }}
-          cxxstd: ${{ matrix.latest-cxxstd }}
-          cc: ${{ steps.setup-cpp.outputs.cc || matrix.cc }}
-          ccflags: ${{ matrix.ccflags }}
-          cxx: ${{ steps.setup-cpp.outputs.cxx || matrix.cxx }}
-          cxxflags: ${{ matrix.cxxflags }}
-          shared: ${{ matrix.shared }}
-          install: false
-          extra-args: -D BOOST_CI_INSTALL_TEST=ON -D CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/.local
-          package: false
-          package-artifact: false
-          ref-source-dir: ../boost-root/libs/url/test/cmake_test
-
-      - name: Root Project CMake Workflow
-        uses: alandefreitas/cpp-actions/cmake-workflow@v1.5.0
+      # Run cmake to build Boost.URL with the module as PROJECT_ROOT
+      - name: Boost.URL as root CMake Workflow
+        uses: alandefreitas/cpp-actions/cmake-workflow@v1.6.1
+        if: ${{ matrix.is-latest || matrix.is-earliest }}
         with:
           source-dir: .
           build-dir: __build_root_test__
@@ -234,13 +298,16 @@ jobs:
           cxx: ${{ steps.setup-cpp.outputs.cxx || matrix.cxx }}
           cxxflags: ${{ matrix.cxxflags }}
           shared: ${{ matrix.shared }}
+          cmake-version: '*'
           extra-args: -D Boost_VERBOSE=ON -D BUILD_TESTING=ON -D BOOST_SRC_DIR="../boost-root"
           package: false
           package-artifact: false
           ref-source-dir: .
+          trace-commands: ${{ env.ACTIONS_STEP_DEBUG == 'true' }}
 
+      # Run b2 to build Boost.URL with the Boost super-project the root directory
       - name: Boost B2 Workflow
-        uses: alandefreitas/cpp-actions/b2-workflow@v1.5.0
+        uses: alandefreitas/cpp-actions/b2-workflow@v1.6.1
         with:
           source-dir: ../boost-root
           modules: url
@@ -255,7 +322,7 @@ jobs:
           shared: ${{ matrix.shared }}
 
       - name: FlameGraph
-        uses: alandefreitas/cpp-actions/flamegraph@v1.5.0
+        uses: alandefreitas/cpp-actions/flamegraph@v1.6.1
         if: matrix.time-trace
         with:
           source-dir: ../boost-root/libs/url
@@ -308,12 +375,13 @@ jobs:
           fetch-depth: 100
 
       - name: Changelog
-        uses: alandefreitas/cpp-actions/create-changelog@v1.5.0
+        uses: alandefreitas/cpp-actions/create-changelog@v1.6.1
         with:
           thank-non-regular: ${{ startsWith(github.ref, 'refs/tags/') }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           limit: 200
-          tag-pattern: 'boost-.*\..*\..*'
+          tag-pattern: 'boost-.+\..+\..+' # Match tags like boost-1.75.0
+          trace-commands: true
 
   antora:
     name: Antora Docs
@@ -338,12 +406,6 @@ jobs:
           sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-14 100
           clang-14 --version
           clang --version
-
-#      The collector script will download mrdocs
-#      - name: Install MrDocs
-#        run: |
-#          wget https://github.com/cppalliance/mrdocs/releases/download/develop-release/MrDocs-1.0.0-Linux.tar.gz
-#          sudo tar -xzf MrDocs-1.0.0-Linux.tar.gz -C /usr/local --strip-components=1
 
       - name: Build Antora Docs
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ set(BOOST_EXCLUDE_LIBRARIES url)
 # Add Boost Subdirectory
 #
 #-------------------------------------------------
-if (NOT BOOST_SUPERPROJECT_VERSION)
+if (BOOST_URL_IS_ROOT)
     set(CMAKE_FOLDER Dependencies)
     # Find absolute BOOST_SRC_DIR
     if (NOT IS_ABSOLUTE ${BOOST_SRC_DIR})
@@ -96,6 +96,7 @@ if (NOT BOOST_SUPERPROJECT_VERSION)
 
     # Create Boost interface targets
     if (BOOST_SRC_DIR_IS_VALID)
+        # From BOOST_SRC_DIR
         set(BOOST_EXCLUDE_LIBRARIES ${PROJECT_NAME})
         set(PREV_BUILD_TESTING ${BUILD_TESTING})
         set(BUILD_TESTING OFF CACHE BOOL "Build the tests." FORCE)
@@ -103,6 +104,7 @@ if (NOT BOOST_SUPERPROJECT_VERSION)
         set(BUILD_TESTING ${PREV_BUILD_TESTING} CACHE BOOL "Build the tests." FORCE)
         set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${BOOST_SRC_DIR}/tools/cmake/include")
     else ()
+        # From Boost Package
         find_package(Boost REQUIRED COMPONENTS container)
         foreach (BOOST_INCLUDE_LIBRARY ${BOOST_INCLUDE_LIBRARIES})
             if (NOT TARGET Boost::${BOOST_INCLUDE_LIBRARY})

--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -12,10 +12,57 @@ set(__ignore__ ${CMAKE_C_COMPILER})
 set(__ignore__ ${CMAKE_C_FLAGS})
 
 if(BOOST_CI_INSTALL_TEST)
+    # Boost as a package (https://github.com/boostorg/cmake#using-boost-after-building-and-installing-it-with-cmake)
     find_package(Boost CONFIG REQUIRED COMPONENTS url)
-else()
+elseif(BOOST_CI_INSTALL_MODULE_TEST)
+    # Boost.URL as a package
+    find_package(boost_url)
+elseif(BOOST_CI_BOOST_SUBDIR_TEST)
+    # Boost as a subdirectory (https://github.com/boostorg/cmake#using-boost-after-building-and-installing-it-with-cmake)
+    if (BUILD_SHARED_LIBS)
+        set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+    endif()
     set(BOOST_URL_BUILD_TESTS OFF CACHE BOOL "Build the tests." FORCE)
-    add_subdirectory(../.. boostorg/url)
+    set(BOOST_INCLUDE_LIBRARIES url)
+    add_subdirectory(../../../.. boost)
+elseif(BOOST_CI_URL_SUBDIR_TEST)
+    # Boost.URL as a subdirectory (https://github.com/boostorg/cmake#using-an-individual-boost-library-with-add_subdirectory)
+    if (BUILD_SHARED_LIBS)
+        set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+    endif()
+    set(BOOST_URL_BUILD_TESTS OFF CACHE BOOL "Build the tests." FORCE)
+    file(GLOB subdirs RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/../../.. ${CMAKE_CURRENT_SOURCE_DIR}/../../../*)
+    foreach(subdir ${subdirs})
+        # This is testing the case when the super-project is not available
+        # and users want to add libraries as subdirectories.
+        # According to the convention above, users should scan all dependencies
+        # with boostdep and include each of them with add_subdirectory.
+        # For developers, hard-coding all dependencies is impractical
+        # and error-prone because the list of transitive dependencies
+        # is unstable over time and across Boost versions and branches.
+        # For this reason, we list all directories in ../.. and add them
+        # as subdirectories. Only directories previously cloned
+        # with `depinst.py` in CI will be added. This will unfortunately
+        # add test dependencies we don't need.
+        if (
+            IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../${subdir} AND
+            EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../../${subdir}/CMakeLists.txt
+        )
+            add_subdirectory(../../../${subdir} boostorg/${subdir})
+        endif()
+    endforeach()
+    if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../../numeric AND IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../numeric)
+        # Iterate potential transitive dependencies in libs/numeric
+        file(GLOB subdirs RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/../../../numeric ${CMAKE_CURRENT_SOURCE_DIR}/../../../numeric/*)
+        foreach(subdir ${subdirs})
+            if (
+                IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../../numeric/${subdir} AND
+                EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../../numeric/${subdir}/CMakeLists.txt
+            )
+                add_subdirectory(../../../numeric/${subdir} boostorg/numeric/${subdir})
+            endif()
+        endforeach()
+    endif()
 endif()
 
 add_executable(main main.cpp)

--- a/test/cmake_test/main.cpp
+++ b/test/cmake_test/main.cpp
@@ -5,11 +5,11 @@
 // https://www.boost.org/LICENSE_1_0.txt
 //
 
-#include <boost/url/url.hpp>
-#include <cassert>
+#include <boost/url.hpp>
 
-int main()
-{
-    assert(sizeof(boost::urls::url) > 0);
-    return 0;
+int main() {
+  boost::urls::ipv4_address ip_addr({127, 0, 0, 1});
+  if (ip_addr.to_bytes().size() != 4) {
+    throw;
+  }
 }


### PR DESCRIPTION
The updated CI workflows include building Boost.URL with the Boost super-project as the project root, with Boost.URL as the project root, building a project that adds the Boost super-project as a subdirectory, a project that adds Boost.URL as a subdirectory, that finds Boost as a package and that finds Boost.URL as a package. The PR also updates cpp-actions to its version v1.6.0, which handles more recent versions of clang.

fix #796