### PR TITLE
fix: handle brackets in query_chars

### DIFF
--- a/include/boost/url/rfc/detail/charsets.hpp
+++ b/include/boost/url/rfc/detail/charsets.hpp
@@ -56,7 +56,7 @@ path_chars =
 constexpr
 auto
 query_chars =
-    pchars + '/' + '?';
+    pchars + '/' + '?' + '[' + ']';
 
 constexpr
 auto

--- a/test/unit/url_base.cpp
+++ b/test/unit/url_base.cpp
@@ -1523,7 +1523,7 @@ struct url_base_test
             u.set_query("!@#$%^&*()_+=-;:'{}[]|\\?/>.<,");
             BOOST_TEST(u.has_query());
             BOOST_TEST(u.encoded_query() ==
-                "!@%23$%25%5E&*()_+=-;:'%7B%7D%5B%5D%7C%5C?/%3E.%3C,");
+                "!@%23$%25%5E&*()_+=-;:'%7B%7D[]%7C%5C?/%3E.%3C,");
             BOOST_TEST_EQ(u.params().size(), 2u);
             BOOST_TEST_EQ((*u.params().begin()).key, "!@#$%^");
             BOOST_TEST_EQ((*u.params().begin()).value, "");

--- a/test/unit/url_view.cpp
+++ b/test/unit/url_view.cpp
@@ -683,6 +683,12 @@ public:
             BOOST_TEST_EQ(u.query(), "k=");
         }
         {
+            url_view u("http://?k[]=");
+            BOOST_TEST(u.has_query());
+            BOOST_TEST_EQ(u.encoded_query(), "k[]=");
+            BOOST_TEST_EQ(u.query(), "k[]=");
+        }
+        {
             url_view u("http://?#");
             BOOST_TEST(u.has_query());
             BOOST_TEST_EQ(u.encoded_query(), "");


### PR DESCRIPTION
Although 1317ca8c includes support for brackets in key_chars, the lack of support in query_chars made still led to errors when the the complete url is parsed at once.

fix #93