### PR TITLE
docs: range::operator= is assignment

### DIFF
--- a/include/boost/url/grammar/range_rule.hpp
+++ b/include/boost/url/grammar/range_rule.hpp
@@ -205,7 +205,7 @@ public:
     */
     range(range const&) noexcept;
 
-    /** Constructor
+    /** Assignment
 
         After the move, this references the
         same underlying character buffer. Ownership


### PR DESCRIPTION
fix #791