### PR TITLE
ci: extract url coverage from all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,19 +268,30 @@ jobs:
         if: matrix.coverage
         run: |
           set -x
-
-          # Generate report
+          
+          # Find gcov
           gcov_tool="gcov"
-          if command -v "gcov-${{ steps.setup-cpp.outputs.version-major }}.${{ steps.setup-cpp.outputs.version-minor }}" &> /dev/null; then
-              gcov_tool="gcov-${{ steps.setup-cpp.outputs.version-major }}.${{ steps.setup-cpp.outputs.version-minor }}"
-          elif command -v "gcov-${{ steps.setup-cpp.outputs.version-major }}" &> /dev/null; then
-              gcov_tool="gcov-${{ steps.setup-cpp.outputs.version-major }}"
-          fi
-          lcov -c -q -o "../boost-root/build_cmake/coverage.info" -d "../boost-root/build_cmake" --include "$(pwd)/../boost-root/libs/${{steps.patch.outputs.module}}/*" --gcov-tool "$gcov_tool"
-
-          # Upload to codecov
-          bash <(curl -s https://codecov.io/bash) -f "../boost-root/build_cmake/coverage.info"
-
+          for version in "${{steps.setup-cpp.outputs.version-major}}.${{steps.setup-cpp.outputs.version-minor}}" "${{steps.setup-cpp.outputs.version-major}}"; do
+            if command -v "gcov-$version" &> /dev/null; then
+              gcov_tool="gcov-$version"
+              break
+            fi
+          done
+          
+          for dir in "../boost-root/build_cmake" "./build_cmake_root" "../boost-root/bin.v2"; do
+              # Generate reports
+              echo "Generate report: $dir"
+              # lcov -c -q -o "$dir/coverage.info" -d "$dir" --include "$(pwd)/../boost-root/libs/${{steps.patch.outputs.module}}/*" --gcov-tool "$gcov_tool"
+              lcov --rc lcov_branch_coverage=0 --gcov-tool "$gcov_tool" --directory "$dir" --capture --output-file "$dir/all.info"
+              lcov --rc lcov_branch_coverage=0 --list "$dir/all.info"
+              lcov --rc lcov_branch_coverage=0 --extract "$dir/all.info" '*/libs/url/*' --output-file "$dir/coverage.info" '*/boost/url*' '*/boost/url.hpp*'
+              lcov --rc lcov_branch_coverage=0 --list "$dir/coverage.info"
+          
+              # Upload to codecov 
+              echo "Upload to codecov: $dir"
+              bash <(curl -s https://codecov.io/bash) -f "$dir/coverage.info"
+          done
+          
           # Summary
           echo "# Coverage" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Use the same process as boost-ci to generate and upload coverage. It generates an all.info file with information about all boost libraries and filters the files in */libs/url/*. This fixes a problem with the --include pattern we used to use.

fix #821