### PR TITLE
test: static_url url_base functions

### DIFF
--- a/include/boost/url/static_url.hpp
+++ b/include/boost/url/static_url.hpp
@@ -92,7 +92,7 @@ class BOOST_URL_DECL
 
     @par Invariants
     @code
-    this->capacity() == Capacity
+    this->capacity() == Capacity + 1
     @endcode
 
     @tparam Capacity The maximum capacity

--- a/src/static_url.cpp
+++ b/src/static_url.cpp
@@ -62,11 +62,28 @@ reserve_impl(
 
 //----------------------------------------------------------
 
+// LCOV_EXCL_START
 void
 static_url_base::
 cleanup(op_t&)
 {
+    /*
+     * The cleanup function is a blank
+     * override as it's unreachable
+     * for static_url_base.
+     *
+     * `u.cleanup()` is called by `op_t` when
+     * the `op_t::old` string is being replaced.
+     * This never happens for `static_url_base`
+     * because it always uses the same buffer.
+     *
+     * `url::reserve_impl` is the only function
+     * that sets the `op_t::old` string but
+     * `static_url_base::reserve_impl` does
+     * not touch `op_t::old`.
+     */
 }
+// LCOV_EXCL_STOP
 
 } // urls
 } // boost

--- a/test/unit/static_url.cpp
+++ b/test/unit/static_url.cpp
@@ -82,6 +82,14 @@ struct static_url_test
         {
             {
                 core::string_view s = "/path/to/file.txt";
+                static_url<20> u0(s);
+                static_url<20> u1(u0);
+                BOOST_TEST_EQ(u0.buffer(), u1.buffer());
+                BOOST_TEST_NE(u0.buffer().data(), s.data());
+                BOOST_TEST_NE(u1.buffer().data(), s.data());
+            }
+            {
+                core::string_view s = "/path/to/file.txt";
                 static_url<24> u0(s);
                 static_url<20> u1(u0);
                 BOOST_TEST_EQ(u0.buffer(), u1.buffer());
@@ -150,6 +158,24 @@ struct static_url_test
     }
 
     void
+    testUrlBase()
+    {
+        {
+            static_url<64> u("http://example.com");
+            BOOST_TEST_EQ(u.buffer(), "http://example.com");
+            u.reserve(32);
+            BOOST_TEST_EQ(u.capacity(), 65);
+        }
+        {
+            static_url<64> u("http://example.com");
+            BOOST_TEST_EQ(u.buffer(), "http://example.com");
+            u.clear();
+            BOOST_TEST_EQ(u.buffer(), "");
+            BOOST_TEST_EQ(u.capacity(), 65);
+        }
+    }
+
+    void
     testOstream()
     {
         {
@@ -191,6 +217,7 @@ struct static_url_test
     run()
     {
         testSpecial();
+        testUrlBase();
         testOstream();
         testJavadocs();
     }


### PR DESCRIPTION
This commit includes tests for the url_base functions whose behavior is customized by static_url.

This is a partial solution to #828, where static_url.cpp has low coverage.