### PR TITLE
test: authority_view host functions

### DIFF
--- a/src/authority_view.cpp
+++ b/src/authority_view.cpp
@@ -200,12 +200,6 @@ encoded_host_address() const noexcept
     std::size_t n;
     switch(u_.host_type_)
     {
-    default:
-    case urls::host_type::none:
-        BOOST_ASSERT(s.empty());
-        n = 0;
-        break;
-
     case urls::host_type::name:
     case urls::host_type::ipv4:
         n = u_.decoded_[id_host];
@@ -224,6 +218,22 @@ encoded_host_address() const noexcept
         n = u_.decoded_[id_host] - 2;
         break;
     }
+    // LCOV_EXCL_START
+    default:
+    case urls::host_type::none:
+        /*
+         * This condition is for correctness
+         * only.
+         * This should never happen, because
+         * the `host_rule` will set the host
+         * type to `name` when it's empty.
+         * This is correct because `reg-name`
+         * accepts empty strings.
+         */
+        BOOST_ASSERT(s.empty());
+        n = 0;
+        break;
+    // LCOV_EXCL_STOP
     }
     return make_pct_string_view_unsafe(
         s.data(), s.size(), n);

--- a/test/unit/authority_view.cpp
+++ b/test/unit/authority_view.cpp
@@ -95,6 +95,14 @@ public:
         yes(":%61@x", ":%61", ":a");
         yes("%61%3a%62@x", "%61%3a%62", "a:b");
 
+        // issue 828
+        {
+            auto a = parse_authority("").value();
+            BOOST_TEST_NOT(a.has_userinfo());
+            BOOST_TEST(a.encoded_userinfo() == "");
+            BOOST_TEST(a.userinfo() == "");
+        }
+
         {
             auto a = parse_authority("@").value();
             BOOST_TEST(a.has_userinfo());
@@ -178,6 +186,9 @@ public:
                 host_type::name);
             BOOST_TEST(a.encoded_host() ==
                 "");
+            BOOST_TEST(a.encoded_host_address() ==
+                "");
+            BOOST_TEST(a.encoded_host_name() == "");
             BOOST_TEST(a.host_ipv4_address()
                 == ipv4_address());
             BOOST_TEST(a.host_ipv6_address()
@@ -191,6 +202,9 @@ public:
                 host_type::name);
             BOOST_TEST(a.encoded_host() ==
                 "");
+            BOOST_TEST(a.encoded_host_address() ==
+                "");
+            BOOST_TEST(a.encoded_host_name() == "");
         }
         {
             auto a = parse_authority("").value();
@@ -198,12 +212,16 @@ public:
                 host_type::name);
             BOOST_TEST(a.encoded_host() ==
                 "");
+            BOOST_TEST(a.encoded_host_address() ==
+                "");
         }
         {
             auto a = parse_authority("www.example.com").value();
             BOOST_TEST(a.host_type() ==
                 host_type::name);
             BOOST_TEST(a.encoded_host() ==
+                "www.example.com");
+            BOOST_TEST(a.encoded_host_address() ==
                 "www.example.com");
             BOOST_TEST(a.host() ==
                 "www.example.com");
@@ -214,6 +232,9 @@ public:
                 host_type::ipv4);
             BOOST_TEST(a.encoded_host() ==
                 "192.168.0.1");
+            BOOST_TEST(a.encoded_host_address() ==
+                "192.168.0.1");
+            BOOST_TEST(a.encoded_host_name() == "");
             BOOST_TEST(a.host() ==
                 "192.168.0.1");
             BOOST_TEST(
@@ -227,6 +248,8 @@ public:
                 host_type::ipv6);
             BOOST_TEST(a.encoded_host() ==
                 "[1::6:192.168.0.1]");
+            BOOST_TEST(a.encoded_host_address() ==
+                "1::6:192.168.0.1");
             BOOST_TEST(a.host() ==
                 "[1::6:192.168.0.1]");
             BOOST_TEST(a.host_ipv6_address() ==
@@ -239,6 +262,8 @@ public:
                 host_type::ipvfuture);
             BOOST_TEST(a.encoded_host() ==
                 "[v1.x]");
+            BOOST_TEST(a.encoded_host_address() ==
+                "v1.x");
             BOOST_TEST(a.host() ==
                 "[v1.x]");
             BOOST_TEST(a.host_ipvfuture() == "v1.x");
@@ -335,6 +360,15 @@ public:
     }
 
     void
+    testOStream()
+    {
+        authority_view a( "user:pass@www.example.com:8080" );
+        std::ostringstream os;
+        os << a;
+        BOOST_TEST_EQ( os.str(), "user:pass@www.example.com:8080" );
+    }
+
+    void
     run()
     {
         // javadocs
@@ -357,6 +391,7 @@ public:
         testHost();
         testPort();
         testHostAndPort();
+        testOStream();
     }
 };
 


### PR DESCRIPTION
This commit includes tests for the authority_view host functions when the host type is invalid.

This is a partial solution to #828, where authority_view.cpp has low coverage.