### PR TITLE
test: cover pct_string_view::decode

### DIFF
--- a/src/detail/decode.cpp
+++ b/src/detail/decode.cpp
@@ -54,74 +54,73 @@ decode_bytes_unsafe(
     return dn;
 }
 
+template <bool SpaceAsPlus>
 std::size_t
-decode_unsafe(
+decode_unsafe_is_plus_impl(char c);
+
+template <>
+std::size_t
+decode_unsafe_is_plus_impl<true>(char c)
+{
+    return c == '+';
+}
+
+template <>
+std::size_t
+decode_unsafe_is_plus_impl<false>(char)
+{
+    return false;
+}
+
+
+template <bool SpaceAsPlus>
+std::size_t
+decode_unsafe_impl(
     char* const dest0,
     char const* end,
-    core::string_view s,
-    encoding_opts opt) noexcept
+    core::string_view s) noexcept
 {
     auto it = s.data();
     auto const last = it + s.size();
     auto dest = dest0;
 
-    if(opt.space_as_plus)
-    {
-        while(it != last)
-        {
-            if(dest == end)
-            {
-                // dest too small
-                return dest - dest0;
-            }
-            if(*it == '+')
-            {
-                // plus to space
-                *dest++ = ' ';
-                ++it;
-                continue;
-            }
-            if(*it == '%')
-            {
-                // escaped
-                ++it;
-                if(last - it < 2)
-                {
-                    // missing input,
-                    // initialize output
-                    std::memset(dest,
-                        0, end - dest);
-                    return dest - dest0;
-                }
-                *dest++ = decode_one(it);
-                it += 2;
-                continue;
-            }
-            // unescaped
-            *dest++ = *it++;
-        }
-        return dest - dest0;
-    }
-
     while(it != last)
     {
+        // LCOV_EXCL_START
         if(dest == end)
         {
-            // dest too small
+            /*
+             * dest too small: unreachable
+             * public functions always pass
+             * a buffer of sufficient size
+             */
             return dest - dest0;
+        }
+        // LCOV_EXCL_STOP
+        if(decode_unsafe_is_plus_impl<SpaceAsPlus>(*it))
+        {
+            // plus to space
+            *dest++ = ' ';
+            ++it;
+            continue;
         }
         if(*it == '%')
         {
             // escaped
             ++it;
+            // LCOV_EXCL_START
             if(last - it < 2)
             {
-                // missing input,
+                // `%` not followed by two hex digits
+                // invalid input: unreachable
+                // public functions always pass
+                // a valid string_view.
                 // initialize output
                 std::memset(dest,
                     0, end - dest);
                 return dest - dest0;
             }
+            // LCOV_EXCL_STOP
             *dest++ = decode_one(it);
             it += 2;
             continue;
@@ -130,6 +129,22 @@ decode_unsafe(
         *dest++ = *it++;
     }
     return dest - dest0;
+}
+
+std::size_t
+decode_unsafe(
+    char* const dest0,
+    char const* end,
+    core::string_view s,
+    encoding_opts opt) noexcept
+{
+    if(opt.space_as_plus)
+    {
+        return decode_unsafe_impl<true>(
+            dest0, end, s);
+    }
+    return decode_unsafe_impl<false>(
+        dest0, end, s);
 }
 
 } // detail


### PR DESCRIPTION
This commit simplifies duplicated code so that we tests all paths for the pct_string_view::decode function. Unreachable paths are also marked.

This is a partial solution to #828, where src/detail/decode.cpp has low coverage.