### PR TITLE
test: shared recycled_ptrs

### DIFF
--- a/src/grammar/detail/recycled.cpp
+++ b/src/grammar/detail/recycled.cpp
@@ -61,6 +61,11 @@ recycled_add_impl(
 {
     auto& a = all_reports_;
 
+    // LCOV_EXCL_START
+    /*
+     * We can't guarantee coverage
+     * exercise of this path.
+     */
     std::size_t new_count = ++a.count;
     std::size_t old_count_max = a.count_max;
     while (
@@ -83,6 +88,7 @@ recycled_add_impl(
         !a.alloc_max.compare_exchange_weak(
             old_alloc_max, n))
     {}
+    // LCOV_EXCL_STOP
 }
 
 void

--- a/test/unit/grammar/recycled.cpp
+++ b/test/unit/grammar/recycled.cpp
@@ -20,13 +20,9 @@ namespace grammar {
 struct recycled_test
 {
     void
-    testPtr()
-    {
-    }
-
-    void
     run()
     {
+        // basic
         {
             recycled_ptr<std::string> sp;
             sp->reserve(1000);
@@ -35,6 +31,21 @@ struct recycled_test
         {
             recycled_ptr<std::string> sp;
             BOOST_TEST(sp->capacity() >= 1000);
+        }
+
+        // shared
+        {
+            recycled_ptr<std::string> sp;
+            auto sp2 = sp;
+            sp->reserve(1000);
+            BOOST_TEST(sp->capacity() >= 1000);
+            BOOST_TEST(sp2->capacity() >= 1000);
+        }
+        {
+            recycled_ptr<std::string> sp;
+            recycled_ptr<std::string> sp2(sp);
+            BOOST_TEST(sp->capacity() >= 1000);
+            BOOST_TEST(sp2->capacity() >= 1000);
         }
 
         // coverage


### PR DESCRIPTION
This commit includes tests for shared `recycled_ptr`s. Unreachable paths are also marked.

This is the last in a series of commits that intend to fix #828, where `recycled_ptr` had low coverage.

fix #828