### PR TITLE
Antora docs: modify dir copy step

### DIFF
--- a/doc/generate-files.mjs
+++ b/doc/generate-files.mjs
@@ -175,9 +175,9 @@ if (isBoostDir(cwdParentParent)) {
     execSync(`rm -rf ${selfDir}`)
 
     // Copy contents of cwd to boost/libs/self
-    const selfDirParent = path.join(boostDir, 'libs')
-    console.log(`Copying ${cwd} to ${selfDirParent}`)
-    execSync(`cp -r ${cwd} ${selfDirParent}`)
+    // const selfDirParent = path.join(boostDir, 'libs')
+    console.log(`Copying ${cwd} to ${selfDir}`)
+    execSync(`cp -r ${cwd} ${selfDir}`)
 }
 
 /*


### PR DESCRIPTION
This is to solve a case where selfDir is not literally "url" but might be "url-docs" or similar. Which is why the `${selfDir}` variable was added, to start with.