### PR TITLE
ci: node20 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,23 +53,22 @@ jobs:
       matrix: ${{ steps.cpp-matrix.outputs.matrix }}
     steps:
       - name: Generate Test Matrix
-        uses: alandefreitas/cpp-actions/cpp-matrix@v1.8.2
+        uses: alandefreitas/cpp-actions/cpp-matrix@v1.8.3
         id: cpp-matrix
         with:
           compilers: |
             gcc >=4.8
-            clang >=3.8 <18
+            clang >=3.8
             msvc >=14.20
             apple-clang *
             mingw *
             clang-cl *
           standards: '>=11'
-          latest-factors: |
-            gcc Coverage UBSan
+          latest-factors: ''
           factors: |
-            gcc ASan Shared No-Threads
+            gcc  Coverage ASan UBSan Shared No-Threads
             msvc Shared x86
-            clang Time-Trace Fuzz ASan+UBSan IntegerSan
+            clang ASan UBSan IntegerSan Time-Trace Fuzz
             mingw Shared
           trace-commands: true
 
@@ -90,25 +89,39 @@ jobs:
     timeout-minutes: 120
 
     steps:
+      # GitHub Actions no longer support older containers.
+      # The workaround is to install our own Node.js for the actions.
+      - name: Patch Node
+        # The containers that need Node.js 20 will have volumes set up so that
+        # the Node.js 20 installation can go there.
+        if: ${{ matrix.container.volumes }}
+        run: |
+          set -x
+          apt-get update
+          apt-get install -y curl xz-utils
+          curl -LO https://unofficial-builds.nodejs.org/download/release/v20.9.0/node-v20.9.0-linux-x64-glibc-217.tar.xz
+          tar -xf node-v20.9.0-linux-x64-glibc-217.tar.xz --strip-components 1 -C /node20217
+          ldd /__e/node20/bin/node
+
       - name: Clone Boost.URL
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup C++
-        uses: alandefreitas/cpp-actions/setup-cpp@v1.8.2
+        uses: alandefreitas/cpp-actions/setup-cpp@v1.8.3
         id: setup-cpp
         with:
           compiler: ${{ matrix.compiler }}
-          version: ${{ (matrix.subrange-policy == 'one-per-major' && matrix.major) || matrix.version }}
+          version: ${{ matrix.version }}
 
       - name: Install packages
         if: matrix.install != ''
-        uses: alandefreitas/cpp-actions/package-install@v1.8.2
+        uses: alandefreitas/cpp-actions/package-install@v1.8.3
         id: package-install
         with:
           apt-get: ${{ matrix.install }}
 
       - name: Clone Boost
-        uses: alandefreitas/cpp-actions/boost-clone@v1.8.2
+        uses: alandefreitas/cpp-actions/boost-clone@v1.8.3
         id: boost-clone
         with:
           branch: ${{ (github.ref_name == 'master' && github.ref_name) || 'develop' }}
@@ -166,7 +179,7 @@ jobs:
 
       - name: Fuzz corpus
         if: matrix.fuzz
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v4
         id: cache-corpus
         with:
           path: ${{ steps.patch.outputs.workspace_root }}/corpus.tar
@@ -176,7 +189,7 @@ jobs:
             corpus-
 
       - name: CMake Workflow
-        uses: alandefreitas/cpp-actions/cmake-workflow@v1.8.2
+        uses: alandefreitas/cpp-actions/cmake-workflow@v1.8.3
         if: matrix.is-no-factor-intermediary != 'true'
         with:
           source-dir: ../boost-root
@@ -196,7 +209,7 @@ jobs:
           trace-commands: true
 
       - name: CMake Integration Workflow
-        uses: alandefreitas/cpp-actions/cmake-workflow@v1.8.2
+        uses: alandefreitas/cpp-actions/cmake-workflow@v1.8.3
         if: matrix.is-no-factor-intermediary != 'true'
         with:
           source-dir: ../boost-root/libs/${{ steps.patch.outputs.module }}/test/cmake_test
@@ -212,7 +225,7 @@ jobs:
           trace-commands: true
 
       - name: CMake Root Workflow
-        uses: alandefreitas/cpp-actions/cmake-workflow@v1.8.2
+        uses: alandefreitas/cpp-actions/cmake-workflow@v1.8.3
         if: matrix.is-no-factor-intermediary != 'true'
         with:
           source-dir: .
@@ -229,7 +242,7 @@ jobs:
           trace-commands: true
 
       - name: B2 Workflow
-        uses: alandefreitas/cpp-actions/b2-workflow@v1.8.2
+        uses: alandefreitas/cpp-actions/b2-workflow@v1.8.3
         env:
           # Set flags via B2 options exclusively
           CFLAGS: ''
@@ -257,7 +270,7 @@ jobs:
           warnings-as-errors: ${{ matrix.is-latest }}
 
       - name: FlameGraph
-        uses: alandefreitas/cpp-actions/flamegraph@v1.8.2
+        uses: alandefreitas/cpp-actions/flamegraph@v1.8.3
         if: matrix.time-trace
         with:
           source-dir: ../boost-root/libs/url
@@ -322,13 +335,13 @@ jobs:
 
     steps:
       - name: Clone Boost.URL
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Avoid the common API rate limit exceeded error in boostorg by including 100 latest commits in any case
           fetch-depth: 100
 
       - name: Changelog
-        uses: alandefreitas/cpp-actions/create-changelog@v1.8.2
+        uses: alandefreitas/cpp-actions/create-changelog@v1.8.3
         with:
           thank-non-regular: ${{ startsWith(github.ref, 'refs/tags/') }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -342,14 +355,14 @@ jobs:
     runs-on: ${{ fromJSON(needs.runner-selection.outputs.labelmatrix)['ubuntu-latest'] }}
     steps:
       - name: Clone Boost.URL
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
 
       - name: Setup C++
-        uses: alandefreitas/cpp-actions/setup-cpp@v1.8.2
+        uses: alandefreitas/cpp-actions/setup-cpp@v1.8.3
         id: setup-cpp
         with:
           compiler: clang
@@ -361,7 +374,7 @@ jobs:
           bash ./build_antora.sh
 
       - name: Create Antora Docs Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: antora-docs
           path: doc/build/site

--- a/extra/test_suite.hpp
+++ b/extra/test_suite.hpp
@@ -217,8 +217,7 @@ inline std::string test_output_impl( char const& v )
     else
     {
         char buffer[ 8 ];
-        std::sprintf( buffer, "\\x%02X", static_cast<unsigned char>( v ) );
-
+        std::snprintf( buffer, sizeof(buffer), "\\x%02X", static_cast<unsigned char>( v ) );
         return buffer;
     }
 }

--- a/test/unit/natvis.cpp
+++ b/test/unit/natvis.cpp
@@ -80,9 +80,11 @@ struct natvis_test
         {
             auto const& c1 = boost::system::generic_category();
             auto const& c2 = boost::system::system_category();
-            auto const& c3 = system::error_code(std::error_code()).category();
+            system::error_code e3{std::error_code()};
+            auto const& c3 = e3.category();
             auto const& c4 = my_category();
-            auto const& c5 = system::error_code(error::not_a_base).category();
+            system::error_code e5(error::not_a_base);
+            auto const& c5 = e5.category();
             ignore_unused(c1, c2, c3, c4, c5);
         }
 


### PR DESCRIPTION
This PR fixes all CI problems related to GHA upgrading to node 20. It also updates the matrix to include the latest compilers.