### PR TITLE
Docs: detect version of clang++

### DIFF
--- a/doc/build_antora.sh
+++ b/doc/build_antora.sh
@@ -7,6 +7,21 @@
 # Official repository: https://github.com/boostorg/url
 #
 
+set -e
+
+# If CXX was not already set, then determine the newest clang.
+if [ ! -n "$CXX" ]; then
+    for i in $(seq 40 -1 18); do
+        if [ -f /usr/bin/clang++-${i} ]; then
+            export CXX="/usr/bin/clang++-$i"
+            export CC="/usr/bin/clang-$i"
+            break
+        fi
+    done
+fi
+
+set -x
+
 if [ $# -eq 0 ]
   then
     echo "No playbook supplied, using default playbook"
@@ -24,4 +39,3 @@ PATH="$(pwd)/node_modules/.bin:${PATH}"
 export PATH
 npx antora --clean --fetch "$PLAYBOOK"
 echo "Done"
-


### PR DESCRIPTION
@alandefreitas wrote: "@sdarwin The Antora workflow that generates the preview will probably break again." Yes the same issue occurred on http_proto.  This fix allows `build_antora.sh` to be run locally, or from another location, not depending on inputs from CI.