### PR TITLE
refactor(url_base): copy operation uses reference to underlying implementation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -130,8 +130,8 @@ In particular, this is of interest to users who wish to compose parsing algorith
 
 [source,bash]
 ----
-cmake -G "Visual Studio 17 2022" -A Win32 -B bin -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/msvc.cmake
-cmake -G "Visual Studio 17 2022" -A x64 -B bin64 -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/msvc.cmake
+cmake -G "Visual Studio 17 2022" -A Win32 -B bin -D BUILD_TESTING -D CMAKE_TOOLCHAIN_FILE=cmake/toolchains/msvc.cmake
+cmake -G "Visual Studio 17 2022" -A x64 -B bin64 -D BUILD_TESTING -D CMAKE_TOOLCHAIN_FILE=cmake/toolchains/msvc.cmake
 ----
 
 == Quick Look

--- a/include/boost/url/url_base.hpp
+++ b/include/boost/url/url_base.hpp
@@ -2922,11 +2922,6 @@ private:
         detail::any_params_iter&&) ->
             detail::params_iter_impl;
 
-    system::result<void>
-    resolve_impl(
-        url_view_base const& base,
-        url_view_base const& ref);
-
     template<class CharSet>
     void normalize_octets_impl(int,
         CharSet const& allowed, op_t&) noexcept;

--- a/src/url_base.cpp
+++ b/src/url_base.cpp
@@ -129,7 +129,7 @@ copy(url_view_base const& u)
     }
     reserve_impl(
         u.size(), op);
-    impl_ = u.impl_;
+    impl_ = *u.pi_;
     impl_.cs_ = s_;
     impl_.from_ = {from::url};
     std::memcpy(s_,

--- a/test/unit/url_view.cpp
+++ b/test/unit/url_view.cpp
@@ -83,6 +83,35 @@ public:
             BOOST_TEST_EQ(u1.data(), u2.data());
         }
 
+        // issue #872
+        {
+            url base{"https://127.0.0.1"};
+            url_view ref = "/foo";
+
+            // url_view(url)
+            {
+                url_view base_view{base};
+                BOOST_TEST(base_view.has_scheme());
+                url dest;
+                auto res = resolve(base_view, ref, dest);
+                BOOST_TEST(res);
+                BOOST_TEST(dest.has_scheme());
+                BOOST_TEST_EQ(dest.buffer(), "https://127.0.0.1/foo");
+            }
+
+            // url_view::operator=(url)
+            {
+                url_view base_view;
+                base_view = base;
+                BOOST_TEST(base_view.has_scheme());
+                url dest;
+                auto res = resolve(base_view, ref, dest);
+                BOOST_TEST(res);
+                BOOST_TEST(dest.has_scheme());
+                BOOST_TEST_EQ(dest.buffer(), "https://127.0.0.1/foo");
+            }
+        }
+
         // url_view(core::string_view)
         {
             BOOST_TEST_NO_THROW(url_view(


### PR DESCRIPTION
The copy operation from a url_view_base should use the pointed implementation rather than the underlying implementation so that url_views that refer to other urls are accounted for.

fix #872