### PR TITLE
docs: set -e

### DIFF
--- a/doc/build_antora.sh
+++ b/doc/build_antora.sh
@@ -7,6 +7,8 @@
 # Official repository: https://github.com/boostorg/url
 #
 
+set -xe
+
 if [ $# -eq 0 ]
   then
     echo "No playbook supplied, using default playbook"


### PR DESCRIPTION
Running `build_antora.sh` in CI jobs there is no way of ascertaining if it failed since the last command is

`echo "Done"`

which always returns 0.    A solution could be to move `npx antora` as the last command, so its exit code will be the same as the script itself.   Or enable the bash setting "Exit immediately if a command exits with a non-zero status."