### PR TITLE
docs: redirects from doc/html

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,4 +1,3 @@
-html
 temp
 out.txt
 qbk/reference.qbk

--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -1,0 +1,22 @@
+<html>
+    <head>
+        <title>Boost.URL</title>
+        <meta http-equiv="refresh" content="0; URL=../../doc/antora/url/index.html">
+    </head>
+    <body>
+        Automatic redirection failed, please go to
+        <a href="../../../../doc/antora/url/index.html">../../doc/antora/url/index.html</a>
+        <hr>
+        <tt>
+        Boost.URL<br>
+        <br>
+        Copyright&nbsp;(C)&nbsp;2022&nbsp;Vinnie&nbsp;Falco<br>
+        Copyright&nbsp;(C)&nbsp;2022&nbsp;Alan&nbsp;de&nbsp;Freitas<br>
+        <br>
+        Distributed under the Boost Software License, Version 1.0.
+        (See accompanying file LICENSE_1_0.txt or copy at
+        <a href=http://www.boost.org/LICENSE_1_0.txt>http://www.boost.org/LICENSE_1_0.txt</a>) <br>
+        <br>
+        </tt>
+    </body>
+</html>

--- a/doc/index.html
+++ b/doc/index.html
@@ -1,0 +1,22 @@
+<html>
+    <head>
+        <title>Boost.URL</title>
+        <meta http-equiv="refresh" content="0; URL=../../doc/antora/url/index.html">
+    </head>
+    <body>
+        Automatic redirection failed, please go to
+        <a href="../../../doc/antora/url/index.html">../../doc/antora/url/index.html</a>
+        <hr>
+        <tt>
+        Boost.URL<br>
+        <br>
+        Copyright&nbsp;(C)&nbsp;2022&nbsp;Vinnie&nbsp;Falco<br>
+        Copyright&nbsp;(C)&nbsp;2022&nbsp;Alan&nbsp;de&nbsp;Freitas<br>
+        <br>
+        Distributed under the Boost Software License, Version 1.0.
+        (See accompanying file LICENSE_1_0.txt or copy at
+        <a href=http://www.boost.org/LICENSE_1_0.txt>http://www.boost.org/LICENSE_1_0.txt</a>) <br>
+        <br>
+        </tt>
+    </body>
+</html>


### PR DESCRIPTION
Documentation is in boost/doc/antora/url/index.html, but any user who visits the entry point of the a previous version in boost/libs/url/doc/html/index.html would get a 404.

fix #878