### PR TITLE
refactor(string_view_base): remove hash_value

### DIFF
--- a/include/boost/url/grammar/string_view_base.hpp
+++ b/include/boost/url/grammar/string_view_base.hpp
@@ -857,16 +857,6 @@ public:
 
     //--------------------------------------------
 
-    /** Return the hash of this value
-    */
-    friend
-    std::size_t
-    hash_value(
-        string_view_base const& s) noexcept
-    {
-        return hash_value(s.s_);
-    }
-
     /** Format a string to an output stream
      */
     BOOST_URL_DECL


### PR DESCRIPTION
Since https://github.com/boostorg/core/commit/92f6cfb3ccf977b6a5c615ce174a9d94002b3b0d in Boost.Core, we have been getting "error: use of undeclared identifier 'hash_value'" because hash_value is not part of the interface of core::string_view.

hash_value has been removed from core::string_view because it's redundant. Boost containers don't need it and it does not enable std containers.