### PR TITLE
ci: cpp-actions v1.8.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       matrix: ${{ steps.cpp-matrix.outputs.matrix }}
     steps:
       - name: Generate Test Matrix
-        uses: alandefreitas/cpp-actions/cpp-matrix@v1.8.7
+        uses: alandefreitas/cpp-actions/cpp-matrix@v1.8.8
         id: cpp-matrix
         with:
           compilers: |
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup C++
-        uses: alandefreitas/cpp-actions/setup-cpp@v1.8.7
+        uses: alandefreitas/cpp-actions/setup-cpp@v1.8.8
         id: setup-cpp
         with:
           compiler: ${{ matrix.compiler }}
@@ -119,13 +119,13 @@ jobs:
 
       - name: Install packages
         if: matrix.install != ''
-        uses: alandefreitas/cpp-actions/package-install@v1.8.7
+        uses: alandefreitas/cpp-actions/package-install@v1.8.8
         id: package-install
         with:
           apt-get: ${{ matrix.install }}
 
       - name: Clone Boost
-        uses: alandefreitas/cpp-actions/boost-clone@v1.8.7
+        uses: alandefreitas/cpp-actions/boost-clone@v1.8.8
         id: boost-clone
         with:
           branch: ${{ (github.ref_name == 'master' && github.ref_name) || 'develop' }}
@@ -193,7 +193,7 @@ jobs:
             corpus-
 
       - name: CMake Workflow
-        uses: alandefreitas/cpp-actions/cmake-workflow@v1.8.7
+        uses: alandefreitas/cpp-actions/cmake-workflow@v1.8.8
         if: matrix.is-no-factor-intermediary != 'true'
         with:
           source-dir: ../boost-root
@@ -213,7 +213,7 @@ jobs:
           trace-commands: true
 
       - name: CMake Integration Workflow
-        uses: alandefreitas/cpp-actions/cmake-workflow@v1.8.7
+        uses: alandefreitas/cpp-actions/cmake-workflow@v1.8.8
         if: matrix.is-no-factor-intermediary != 'true'
         with:
           source-dir: ../boost-root/libs/${{ steps.patch.outputs.module }}/test/cmake_test
@@ -229,7 +229,7 @@ jobs:
           trace-commands: true
 
       - name: CMake Root Workflow
-        uses: alandefreitas/cpp-actions/cmake-workflow@v1.8.7
+        uses: alandefreitas/cpp-actions/cmake-workflow@v1.8.8
         if: matrix.is-no-factor-intermediary != 'true'
         with:
           source-dir: .
@@ -246,7 +246,7 @@ jobs:
           trace-commands: true
 
       - name: B2 Workflow
-        uses: alandefreitas/cpp-actions/b2-workflow@v1.8.7
+        uses: alandefreitas/cpp-actions/b2-workflow@v1.8.8
         env:
           # Set flags via B2 options exclusively
           CFLAGS: ''
@@ -274,7 +274,7 @@ jobs:
           warnings-as-errors: ${{ matrix.is-latest }}
 
       - name: FlameGraph
-        uses: alandefreitas/cpp-actions/flamegraph@v1.8.7
+        uses: alandefreitas/cpp-actions/flamegraph@v1.8.8
         if: matrix.time-trace
         with:
           source-dir: ../boost-root/libs/url
@@ -345,7 +345,7 @@ jobs:
           fetch-depth: 100
 
       - name: Changelog
-        uses: alandefreitas/cpp-actions/create-changelog@v1.8.7
+        uses: alandefreitas/cpp-actions/create-changelog@v1.8.8
         with:
           thank-non-regular: ${{ startsWith(github.ref, 'refs/tags/') }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -368,7 +368,7 @@ jobs:
         shell: bash
     steps:
       - name: Install packages
-        uses: alandefreitas/cpp-actions/package-install@v1.8.7
+        uses: alandefreitas/cpp-actions/package-install@v1.8.8
         with:
           apt-get: git cmake
 
@@ -376,7 +376,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Clone Boost
-        uses: alandefreitas/cpp-actions/boost-clone@v1.8.7
+        uses: alandefreitas/cpp-actions/boost-clone@v1.8.8
         id: boost-clone
         with:
           branch: ${{ (github.ref_name == 'master' && github.ref_name) || 'develop' }}


### PR DESCRIPTION
* Support ubuntu noble and clang 19
* Support tags without conventional commits for changelog
* Better handling of multi-config generators
* boost-clone initializes essential modules
* Multiple bug fixes