### PR TITLE
docs: no Doxygen documentation variant

### DIFF
--- a/example/router/impl/router.hpp
+++ b/example/router/impl/router.hpp
@@ -53,11 +53,11 @@ insert(core::string_view pattern, U&& v)
 template <class T>
 T const*
 router<T>::
-find(segments_encoded_view path, matches_base& m) const noexcept
+find_impl(segments_encoded_view path, matches_base& m) const noexcept
 {
     core::string_view* matches_it = m.matches();
     core::string_view* ids_it = m.ids();
-    any_resource const* p = find_impl(
+    any_resource const* p = router_base::find_impl(
         path, matches_it, ids_it );
     if (p)
     {

--- a/example/router/router.hpp
+++ b/example/router/router.hpp
@@ -66,19 +66,20 @@ public:
     void
     insert(core::string_view pattern, U&& v);
 
-    /** Match URL path to corresponding resource
+    /** Match URL path to the corresponding resource
 
         @param request Request path
         @return The match results
      */
     T const*
-    find(segments_encoded_view path, matches_base& m) const noexcept;
+    find(segments_encoded_view path, matches& m) const noexcept
+    {
+        return find_impl(path, m);
+    }
 
-#ifdef BOOST_URL_DOCS
-    /// @copydoc find
+private:
     T const*
-    find(segments_encoded_view path, matches& m) const noexcept;
-#endif
+    find_impl(segments_encoded_view path, matches_base& m) const noexcept;
 };
 
 } // urls

--- a/include/boost/url/authority_view.hpp
+++ b/include/boost/url/authority_view.hpp
@@ -85,10 +85,7 @@ class BOOST_URL_DECL
 {
     detail::url_impl u_;
 
-#ifndef BOOST_URL_DOCS
-    // VFALCO docca emits this erroneously
     friend struct detail::url_impl;
-#endif
 
     explicit
     authority_view(

--- a/include/boost/url/decode_view.hpp
+++ b/include/boost/url/decode_view.hpp
@@ -23,7 +23,6 @@ namespace urls {
 
 //------------------------------------------------
 
-#ifndef BOOST_URL_DOCS
 class decode_view;
 
 namespace detail {
@@ -35,7 +34,6 @@ make_decode_view(
     Args&&... args) noexcept;
 
 } // detail
-#endif
 
 //------------------------------------------------
 
@@ -76,13 +74,11 @@ class decode_view
     std::size_t dn_ = 0;
     bool space_as_plus_ = true;
 
-#ifndef BOOST_URL_DOCS
     template<class... Args>
     friend
     decode_view
     detail::make_decode_view(
         Args&&... args) noexcept;
-#endif
 
     // unchecked
     BOOST_CXX14_CONSTEXPR
@@ -1060,7 +1056,6 @@ pct_string_view::operator*() const noexcept
     return decode_view(*this);
 }
 
-#ifndef BOOST_URL_DOCS
 namespace detail {
 template<class... Args>
 decode_view
@@ -1071,7 +1066,6 @@ make_decode_view(
         std::forward<Args>(args)...);
 }
 } // detail
-#endif
 
 //------------------------------------------------
 

--- a/include/boost/url/detail/config.hpp
+++ b/include/boost/url/detail/config.hpp
@@ -135,7 +135,7 @@
 #endif
 
 // deprecated attribute
-#if defined(BOOST_MSVC) || defined(BOOST_URL_DOCS)
+#if defined(BOOST_MSVC)
 #define BOOST_URL_DEPRECATED(msg)
 #else
 #define BOOST_URL_DEPRECATED(msg) BOOST_DEPRECATED(msg)

--- a/include/boost/url/encode.hpp
+++ b/include/boost/url/encode.hpp
@@ -125,8 +125,6 @@ encode(
     CS const& allowed,
     encoding_opts opt = {});
 
-#ifndef BOOST_URL_DOCS
-// VFALCO semi-private for now
 template<BOOST_URL_CONSTRAINT(grammar::CharSet) CS>
 std::size_t
 encode_unsafe(
@@ -135,7 +133,6 @@ encode_unsafe(
     core::string_view s,
     CS const& allowed,
     encoding_opts opt);
-#endif
 
 //------------------------------------------------
 

--- a/include/boost/url/error_types.hpp
+++ b/include/boost/url/error_types.hpp
@@ -128,52 +128,7 @@ using system_error
     the library.
 
  */
-#ifdef BOOST_URL_DOCS
-error_category const& generic_category();
-#else
-
-/** A function to return the generic error category used by the library
-
-    @warning This alias is no longer supported and
-    should not be used in new code. Please use
-    `core::string_view` instead.
-
-    This alias is included for backwards
-    compatibility with earlier versions of the
-    library.
-
-    However, it will be removed in future releases,
-    and using it in new code is not recommended.
-
-    Please use the updated version instead to
-    ensure compatibility with future versions of
-    the library.
-
- */
 using boost::system::generic_category;
-#endif
-
-/** A function to return the system error category used by the library
-
-    @warning This alias is no longer supported and
-    should not be used in new code. Please use
-    `core::string_view` instead.
-
-    This alias is included for backwards
-    compatibility with earlier versions of the
-    library.
-
-    However, it will be removed in future releases,
-    and using it in new code is not recommended.
-
-    Please use the updated version instead to
-    ensure compatibility with future versions of
-    the library.
-
- */
-#ifdef BOOST_URL_DOCS
-error_category const& system_category();
-#else
 
 /** A function to return the system error category used by the library
 
@@ -194,7 +149,6 @@ error_category const& system_category();
 
  */
 using boost::system::system_category;
-#endif
 
 /** The set of constants used for cross-platform error codes
 

--- a/include/boost/url/grammar/all_chars.hpp
+++ b/include/boost/url/grammar/all_chars.hpp
@@ -16,30 +16,6 @@
 namespace boost {
 namespace urls {
 namespace grammar {
-
-/** The set of all characters
-
-    @par Example
-    Character sets are used with rules and the
-    functions @ref find_if and @ref find_if_not.
-    @code
-    system::result< core::string_view > rv = parse( "JohnDoe", token_rule( all_chars ) );
-    @endcode
-
-    @par BNF
-    @code
-    ALL       = %x00-FF
-    @endcode
-
-    @see
-        @ref find_if,
-        @ref find_if_not,
-        @ref parse,
-        @ref token_rule.
-*/
-#ifdef BOOST_URL_DOCS
-constexpr __implementation_defined__ all_chars;
-#else
 namespace implementation_defined
 {
 struct all_chars_t
@@ -97,7 +73,6 @@ struct all_chars_t
         @ref token_rule.
 */
 BOOST_INLINE_VARIABLE constexpr implementation_defined::all_chars_t all_chars{};
-#endif
 
 } // grammar
 } // urls

--- a/include/boost/url/grammar/alnum_chars.hpp
+++ b/include/boost/url/grammar/alnum_chars.hpp
@@ -16,40 +16,6 @@
 namespace boost {
 namespace urls {
 namespace grammar {
-
-/** The set of letters and digits
-
-    @par Example
-    Character sets are used with rules and the
-    functions @ref find_if and @ref find_if_not.
-    @code
-    system::result< core::string_view > = parse( "Johnny42", token_rule( alnumchars ) );
-    @endcode
-
-    @par BNF
-    @code
-    ALNUM       = ALPHA / DIGIT
-
-    ALPHA       = %x41-5A / %x61-7A
-                ; A-Z / a-z
-
-    DIGIT       = %x30-39
-                ; 0-9
-    @endcode
-
-    @par Specification
-    @li <a href="https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1"
-        >B.1. Core Rules (rfc5234)</a>
-
-    @see
-        @ref find_if,
-        @ref find_if_not,
-        @ref parse,
-        @ref token_rule.
-*/
-#ifdef BOOST_URL_DOCS
-constexpr __implementation_defined__ alnum_chars;
-#else
 namespace implementation_defined {
 struct alnum_chars_t
 {
@@ -116,7 +82,6 @@ struct alnum_chars_t
         @ref token_rule.
 */
 constexpr implementation_defined::alnum_chars_t alnum_chars{};
-#endif
 
 } // grammar
 } // urls

--- a/include/boost/url/grammar/alpha_chars.hpp
+++ b/include/boost/url/grammar/alpha_chars.hpp
@@ -16,35 +16,6 @@
 namespace boost {
 namespace urls {
 namespace grammar {
-
-/** The set of all letters
-
-    @par Example
-    Character sets are used with rules and the
-    functions @ref find_if and @ref find_if_not.
-    @code
-    system::result< core::string_view > rv = parse( "JohnDoe", token_rule( alpha_chars ) );
-    @endcode
-
-    @par BNF
-    @code
-    ALPHA       = %x41-5A / %x61-7A
-                ; A-Z / a-z
-    @endcode
-
-    @par Specification
-    @li <a href="https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1"
-        >B.1. Core Rules (rfc5234)</a>
-
-    @see
-        @ref find_if,
-        @ref find_if_not,
-        @ref parse,
-        @ref token_rule.
-*/
-#ifdef BOOST_URL_DOCS
-constexpr __implementation_defined__ alpha_chars;
-#else
 namespace implementation_defined {
 struct alpha_chars_t
 {
@@ -108,7 +79,6 @@ struct alpha_chars_t
         @ref token_rule.
 */
 constexpr implementation_defined::alpha_chars_t alpha_chars{};
-#endif
 
 } // grammar
 } // urls

--- a/include/boost/url/grammar/dec_octet_rule.hpp
+++ b/include/boost/url/grammar/dec_octet_rule.hpp
@@ -16,43 +16,6 @@
 namespace boost {
 namespace urls {
 namespace grammar {
-
-/** Match a decimal octet
-
-    A decimal octet is precise way of
-    saying a number from 0 to 255. These
-    are commonly used in IPv4 addresses.
-
-    @par Value Type
-    @code
-    using value_type = unsigned char;
-    @endcode
-
-    @par Example
-    Rules are used with the function @ref parse.
-    @code
-    system::result< unsigned char > rv = parse( "255", dec_octet_rule );
-    @endcode
-
-    @par BNF
-    @code
-    dec-octet   = DIGIT                 ; 0-9
-                / %x31-39 DIGIT         ; 10-99
-                / "1" 2DIGIT            ; 100-199
-                / "2" %x30-34 DIGIT     ; 200-249
-                / "25" %x30-35          ; 250-255
-    @endcode
-
-    @par Specification
-    @li <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2"
-        >3.2.2.  Host (rfc3986)</a>
-
-    @see
-        @ref parse.
-*/
-#ifdef BOOST_URL_DOCS
-constexpr __implementation_defined__ dec_octet_rule;
-#else
 namespace implementation_defined {
 struct dec_octet_rule_t
 {
@@ -102,7 +65,6 @@ struct dec_octet_rule_t
         @ref parse.
 */
 constexpr implementation_defined::dec_octet_rule_t dec_octet_rule{};
-#endif
 
 } // grammar
 } // urls

--- a/include/boost/url/grammar/digit_chars.hpp
+++ b/include/boost/url/grammar/digit_chars.hpp
@@ -16,35 +16,6 @@
 namespace boost {
 namespace urls {
 namespace grammar {
-
-/** The set of decimal digits
-
-    @par Example
-    Character sets are used with rules and the
-    functions @ref find_if and @ref find_if_not.
-    @code
-    system::result< core::string_view > rv = parse( "2022", token_rule( digit_chars ) );
-    @endcode
-
-    @par BNF
-    @code
-    DIGIT       = %x30-39
-                ; 0-9
-    @endcode
-
-    @par Specification
-    @li <a href="https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1"
-        >B.1. Core Rules (rfc5234)</a>
-
-    @see
-        @ref find_if,
-        @ref find_if_not,
-        @ref parse,
-        @ref token_rule.
-*/
-#ifdef BOOST_URL_DOCS
-constexpr __implementation_defined__ digit_chars;
-#else
 namespace implementation_defined {
 struct digit_chars_t
 {
@@ -103,7 +74,6 @@ struct digit_chars_t
         @ref token_rule.
 */
 constexpr implementation_defined::digit_chars_t digit_chars{};
-#endif
 
 } // grammar
 } // urls

--- a/include/boost/url/grammar/hexdig_chars.hpp
+++ b/include/boost/url/grammar/hexdig_chars.hpp
@@ -16,48 +16,6 @@
 namespace boost {
 namespace urls {
 namespace grammar {
-
-/** The set of hexadecimal digits
-
-    @par Example
-    Character sets are used with rules and the
-    functions @ref find_if and @ref find_if_not.
-    @code
-    system::result< core::string_view > rv = parse( "8086FC19", token_rule( hexdig_chars ) );
-    @endcode
-
-    @par BNF
-    @code
-    HEXDIG      = DIGIT
-                / "A" / "B" / "C" / "D" / "E" / "F"
-                / "a" / "b" / "c" / "d" / "e" / "f"
-    @endcode
-
-    @note The RFCs are inconsistent on the case
-    sensitivity of hexadecimal digits. Existing
-    uses suggest case-insensitivity is a de-facto
-    standard.
-
-    @par Specification
-    @li <a href="https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1"
-        >B.1. Core Rules (rfc5234)</a>
-    @li <a href="https://datatracker.ietf.org/doc/html/rfc7230#section-1.2"
-        >1.2. Syntax Notation (rfc7230)</a>
-    @li <a href="https://datatracker.ietf.org/doc/html/rfc5952#section-2.3"
-        >2.3. Uppercase or Lowercase (rfc5952)</a>
-    @li <a href="https://datatracker.ietf.org/doc/html/rfc5952#section-4.3"
-        >4.3. Lowercase (rfc5952)</a>
-
-    @see
-        @ref find_if,
-        @ref find_if_not,
-        @ref hexdig_value,
-        @ref parse,
-        @ref token_rule.
-*/
-#ifdef BOOST_URL_DOCS
-constexpr __implementation_defined__ hexdig_chars;
-#else
 namespace implementation_defined {
 struct hexdig_chars_t
 {
@@ -137,13 +95,6 @@ struct hexdig_chars_t
         @ref token_rule.
 */
 constexpr implementation_defined::hexdig_chars_t hexdig_chars{};
-#endif
-
-// VFALCO We can declare
-// these later if needed
-//
-//struct hexdig_upper_chars;
-//struct hexdig_lower_chars;
 
 /** Return the decimal value of a hex character
 
@@ -167,7 +118,7 @@ inline
 signed char
 hexdig_value(char ch) noexcept
 {
-    // Idea for switch statement to
+    // Idea for a switch statement to
     // minimize emitted assembly from
     // Glen Fernandes
     signed char res;

--- a/include/boost/url/grammar/unsigned_rule.hpp
+++ b/include/boost/url/grammar/unsigned_rule.hpp
@@ -49,36 +49,6 @@ namespace grammar {
     @see
         @ref grammar::parse.
 */
-#ifdef BOOST_URL_DOCS
-template<class Unsigned>
-struct unsigned_rule;
-#else
-/** Match an unsigned decimal
-
-    Extra leading zeroes are disallowed.
-
-    @par Value Type
-    @code
-    using value_type = Unsigned;
-    @endcode
-
-    @par Example
-    Rules are used with the function @ref parse.
-    @code
-    system::result< unsigned short > rv = parse( "32767", unsigned_rule< unsigned short >{} );
-    @endcode
-
-    @par BNF
-    @code
-    unsigned      = "0" / ( ["1"..."9"] *DIGIT )
-    @endcode
-
-    @tparam Unsigned The unsigned integer type used
-    to store the result.
-
-    @see
-        @ref grammar::parse.
-*/
 template<class Unsigned>
 struct unsigned_rule
 {
@@ -97,8 +67,6 @@ struct unsigned_rule
             ) const noexcept ->
         system::result<value_type>;
 };
-#endif
-
 } // grammar
 } // urls
 } // boost

--- a/include/boost/url/grammar/vchars.hpp
+++ b/include/boost/url/grammar/vchars.hpp
@@ -16,35 +16,6 @@
 namespace boost {
 namespace urls {
 namespace grammar {
-
-/** The set of visible characters
-
-    @par Example
-    Character sets are used with rules and the
-    functions @ref find_if and @ref find_if_not.
-    @code
-    system::result< core::string_view > rv = parse( "JohnDoe", token_rule( vchars ) );
-    @endcode
-
-    @par BNF
-    @code
-    VCHAR       = 0x21-0x7E
-                ; visible (printing) characters
-    @endcode
-
-    @par Specification
-    @li <a href="https://datatracker.ietf.org/doc/html/rfc5234#appendix-B.1"
-        >B.1. Core Rules (rfc5234)</a>
-
-    @see
-        @ref find_if,
-        @ref find_if_not,
-        @ref parse,
-        @ref token_rule.
-*/
-#ifdef BOOST_URL_DOCS
-constexpr __implementation_defined__ vchars;
-#else
 namespace implementation_defined {
 struct vchars_t
 {
@@ -103,7 +74,6 @@ struct vchars_t
         @ref token_rule.
 */
 constexpr implementation_defined::vchars_t vchars{};
-#endif
 
 } // grammar
 } // urls

--- a/include/boost/url/ipv6_address.hpp
+++ b/include/boost/url/ipv6_address.hpp
@@ -23,9 +23,7 @@
 namespace boost {
 namespace urls {
 
-#ifndef BOOST_URL_DOCS
 class ipv4_address;
-#endif
 
 /** An IP version 6 style address.
 

--- a/include/boost/url/params_encoded_base.hpp
+++ b/include/boost/url/params_encoded_base.hpp
@@ -74,34 +74,7 @@ public:
         it is no longer referenced by any
         container or iterator.
     */
-#ifdef BOOST_URL_DOCS
-    using iterator = __see_below__;
-#else
-
-    /** A Bidirectional iterator to a query parameter
-
-        Objects of this type allow iteration
-        through the parameters in the query.
-        Strings returned by iterators may
-        contain percent escapes.
-        The values returned are read-only;
-        changes to parameters must be made
-        through the container instead, if the
-        container supports modification.
-
-        <br>
-
-        The strings produced when iterators
-        are dereferenced refer to the underlying
-        character buffer.
-        Ownership is not transferred; the caller
-        is responsible for ensuring that the
-        lifetime of the buffer extends until
-        it is no longer referenced by any
-        container or iterator.
-    */
     class iterator;
-#endif
 
     /// @copydoc iterator
     using const_iterator = iterator;

--- a/include/boost/url/rfc/authority_rule.hpp
+++ b/include/boost/url/rfc/authority_rule.hpp
@@ -16,38 +16,6 @@
 
 namespace boost {
 namespace urls {
-
-/** Rule for authority
-
-    @par Value Type
-    @code
-    using value_type = authority_view;
-    @endcode
-
-    @par Example
-    Rules are used with the function @ref grammar::parse.
-    @code
-    system::result< authority_view > rv = grammar::parse( "user:pass@example.com:8080", authority_rule );
-    @endcode
-
-    @par BNF
-    @code
-    authority   = [ userinfo "@" ] host [ ":" port ]
-    @endcode
-
-    @par Specification
-    @li <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.2"
-        >3.2. Authority (rfc3986)</a>
-
-    @see
-        @ref authority_view,
-        @ref grammar::parse,
-        @ref parse_authority.
-*/
-#ifdef BOOST_URL_DOCS
-constexpr __implementation_defined__ authority_rule;
-#else
-
 namespace implementation_defined {
 struct authority_rule_t
 {
@@ -91,7 +59,6 @@ struct authority_rule_t
         @ref parse_authority.
 */
 constexpr implementation_defined::authority_rule_t authority_rule{};
-#endif
 
 } // urls
 } // boost

--- a/include/boost/url/rfc/ipv4_address_rule.hpp
+++ b/include/boost/url/rfc/ipv4_address_rule.hpp
@@ -16,45 +16,6 @@
 
 namespace boost {
 namespace urls {
-
-/** Rule for an IP version 4 style address
-
-    @par Value Type
-    @code
-    using value_type = ipv4_address;
-    @endcode
-
-    @par Example
-    Rules are used with the function @ref grammar::parse.
-    @code
-    system::result< ipv4_address > rv = grammar::parse( "192.168.0.1", ipv4_address_rule );
-    @endcode
-
-    @par BNF
-    @code
-    IPv4address = dec-octet "." dec-octet "." dec-octet "." dec-octet
-
-    dec-octet   = DIGIT                 ; 0-9
-                / %x31-39 DIGIT         ; 10-99
-                / "1" 2DIGIT            ; 100-199
-                / "2" %x30-34 DIGIT     ; 200-249
-                / "25" %x30-35          ; 250-255
-    @endcode
-
-    @par Specification
-    @li <a href="https://en.wikipedia.org/wiki/IPv4"
-        >IPv4 (Wikipedia)</a>
-    @li <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2"
-        >3.2.2. Host (rfc3986)</a>
-
-    @see
-        @ref ipv4_address,
-        @ref parse_ipv4_address,
-        @ref grammar::parse.
-*/
-#ifdef BOOST_URL_DOCS
-constexpr __implementation_defined__ ipv4_address_rule;
-#else
 namespace implementation_defined {
 struct ipv4_address_rule_t
 {
@@ -107,7 +68,6 @@ struct ipv4_address_rule_t
         @ref grammar::parse.
 */
 constexpr implementation_defined::ipv4_address_rule_t ipv4_address_rule{};
-#endif
 
 } // urls
 } // boost

--- a/include/boost/url/rfc/ipv6_address_rule.hpp
+++ b/include/boost/url/rfc/ipv6_address_rule.hpp
@@ -16,53 +16,6 @@
 
 namespace boost {
 namespace urls {
-
-/** Rule for An IP version 6 style address
-
-    @par Value Type
-    @code
-    using value_type = ipv6_address;
-    @endcode
-
-    @par Example
-    Rules are used with the function @ref grammar::parse.
-    @code
-    system::result< ipv6_address > rv = grammar::parse( "2001:0db8:85a3:0000:0000:8a2e:0370:7334", ipv6_address_rule );
-    @endcode
-
-    @par BNF
-    @code
-    IPv6address =                            6( h16 ":" ) ls32
-                /                       "::" 5( h16 ":" ) ls32
-                / [               h16 ] "::" 4( h16 ":" ) ls32
-                / [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) ls32
-                / [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32
-                / [ *3( h16 ":" ) h16 ] "::"    h16 ":"   ls32
-                / [ *4( h16 ":" ) h16 ] "::"              ls32
-                / [ *5( h16 ":" ) h16 ] "::"              h16
-                / [ *6( h16 ":" ) h16 ] "::"
-
-    ls32        = ( h16 ":" h16 ) / IPv4address
-                ; least-significant 32 bits of address
-
-    h16         = 1*4HEXDIG
-                ; 16 bits of address represented in hexadecimal
-    @endcode
-
-    @par Specification
-    @li <a href="https://datatracker.ietf.org/doc/html/rfc4291"
-        >IP Version 6 Addressing Architecture (rfc4291)</a>
-    @li <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2"
-        >3.2.2. Host (rfc3986)</a>
-
-    @see
-        @ref ipv6_address,
-        @ref parse_ipv6_address,
-        @ref grammar::parse.
-*/
-#ifdef BOOST_URL_DOCS
-constexpr __implementation_defined__ ipv6_address_rule;
-#else
 namespace implementation_defined {
 struct ipv6_address_rule_t
 {
@@ -123,7 +76,6 @@ struct ipv6_address_rule_t
         @ref grammar::parse.
 */
 constexpr implementation_defined::ipv6_address_rule_t ipv6_address_rule{};
-#endif
 
 } // urls
 } // boost

--- a/include/boost/url/rfc/pct_encoded_rule.hpp
+++ b/include/boost/url/rfc/pct_encoded_rule.hpp
@@ -17,54 +17,6 @@
 
 namespace boost {
 namespace urls {
-
-/** Rule for a string with percent-encoded escapes
-
-    This function returns a rule which matches
-    a percent-encoded string, permitting characters
-    in the string which are also in the specified
-    character set to be used unescaped.
-   
-    @par Value Type
-    @code
-    using value_type = pct_string_view;
-    @endcode
-
-    @par Example
-    Rules are used with the function @ref grammar::parse.
-    @code
-    //  pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
-
-    system::result< pct_string_view > rv = grammar::parse( "Program%20Files", pct_encoded_rule( pchars ) );
-    @endcode
-
-    @par BNF
-    @code
-    pct-encoded   = "%" HEXDIG HEXDIG
-    @endcode
-
-    @param cs The character set indicating
-    which characters are allowed without escapes.
-    Any character which is not in this set must be
-    escaped, or else parsing returns an error.
-
-    @par Specification
-    @li <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-2.1">
-        2.1. Percent-Encoding (rfc3986)</a>
-
-    @see
-        @ref grammar::parse,
-        @ref pchars,
-        @ref pct_string_view.
-*/
-#ifdef BOOST_URL_DOCS
-/**@{*/
-template<class CharSet>
-constexpr
-__implementation_defined__
-pct_encoded_rule( CharSet const& cs ) noexcept;
-/**@}*/
-#else
 namespace implementation_defined {
 template<class CharSet>
 struct pct_encoded_rule_t
@@ -145,8 +97,6 @@ pct_encoded_rule(CS const& cs) noexcept ->
 
     return implementation_defined::pct_encoded_rule_t<CS>(cs);
 }
-
-#endif
 
 } // urls
 } // boost

--- a/include/boost/url/rfc/query_rule.hpp
+++ b/include/boost/url/rfc/query_rule.hpp
@@ -17,46 +17,6 @@
 
 namespace boost {
 namespace urls {
-
-/** Rule for query
-
-    @par Value Type
-    @code
-    using value_type = params_encoded_view;
-    @endcode
-
-    @par Example
-    Rules are used with the function @ref grammar::parse.
-    @code
-    system::result< params_encoded_view > rv = grammar::parse( "format=web&id=42&compact", query_rule );
-    @endcode
-
-    @par BNF
-    @code
-    query           = *( pchar / "/" / "?" )
-
-    query-params    = [ query-param ] *( "&" query-param )
-    query-param     = key [ "=" value ]
-    key             = *qpchar
-    value           = *( qpchar / "=" )
-    qpchar          = unreserved
-                    / pct-encoded
-                    / "!" / "$" / "'" / "(" / ")"
-                    / "*" / "+" / "," / ";"
-                    / ":" / "@" / "/" / "?"
-    @endcode
-
-    @par Specification
-    @li <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.4"
-        >3.4. Query (rfc3986)</a>
-
-    @see
-        @ref grammar::parse,
-        @ref params_encoded_view.
-*/
-#ifdef BOOST_URL_DOCS
-constexpr __implementation_defined__ query_rule;
-#else
 namespace implementation_defined {
 struct query_rule_t
 {
@@ -71,7 +31,7 @@ struct query_rule_t
 };
 } // implementation_defined
 
-/** Rule for query
+/** Rule for a query string
 
     @par Value Type
     @code
@@ -108,7 +68,6 @@ struct query_rule_t
         @ref params_encoded_view.
 */
 constexpr implementation_defined::query_rule_t query_rule{};
-#endif
 
 } // urls
 } // boost

--- a/include/boost/url/rfc/relative_ref_rule.hpp
+++ b/include/boost/url/rfc/relative_ref_rule.hpp
@@ -16,37 +16,6 @@
 
 namespace boost {
 namespace urls {
-
-/** Rule for relative-ref
-
-    @par Value Type
-    @code
-    using value_type = url_view;
-    @endcode
-
-    @par Example
-    Rules are used with the function @ref grammar::parse.
-    @code
-    system::result< url_view > rv = grammar::parse( "images/dot.gif?v=hide#a", relative_ref_rule );
-    @endcode
-
-    @par BNF
-    @code
-    relative-ref  = relative-part [ "?" query ] [ "#" fragment ]
-    @endcode
-
-    @par Specification
-    @li <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-4.2"
-        >4.2. Relative Reference (rfc3986)</a>
-
-    @see
-        @ref grammar::parse,
-        @ref parse_relative_ref,
-        @ref url_view.
-*/
-#ifdef BOOST_URL_DOCS
-constexpr __implementation_defined__ relative_ref_rule;
-#else
 namespace implementation_defined {
 struct relative_ref_rule_t
 {
@@ -90,7 +59,6 @@ struct relative_ref_rule_t
         @ref url_view.
 */
 constexpr implementation_defined::relative_ref_rule_t relative_ref_rule{};
-#endif
 
 } // urls
 } // boost

--- a/include/boost/url/rfc/uri_reference_rule.hpp
+++ b/include/boost/url/rfc/uri_reference_rule.hpp
@@ -16,40 +16,6 @@
 
 namespace boost {
 namespace urls {
-
-/** Rule for URI-reference
-
-    @par Value Type
-    @code
-    using value_type = url_view;
-    @endcode;
-
-    @par Example
-    Rules are used with the function @ref grammar::parse.
-    @code
-    system::result< url_view > rv = grammar::parse( "ws://echo.example.com/?name=boost#demo", uri_reference_rule );
-    @endcode
-
-    @par BNF
-    @code
-    URI-reference = URI / relative-ref
-
-    URI           = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
-    relative-ref  = relative-part [ "?" query ] [ "#" fragment ]
-    @endcode
-
-    @par Specification
-    @li <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3"
-        >3. Syntax Components (rfc3986)</a>
-
-    @see
-        @ref grammar::parse,
-        @ref parse_uri_reference,
-        @ref url_view.
-*/
-#ifdef BOOST_URL_DOCS
-constexpr __implementation_defined__ uri_reference_rule{};
-#else
 namespace implementation_defined {
 struct uri_reference_rule_t
 {
@@ -96,7 +62,6 @@ struct uri_reference_rule_t
         @ref url_view.
 */
 constexpr implementation_defined::uri_reference_rule_t uri_reference_rule{};
-#endif
 
 } // urls
 } // boost

--- a/include/boost/url/rfc/uri_rule.hpp
+++ b/include/boost/url/rfc/uri_rule.hpp
@@ -16,37 +16,6 @@
 
 namespace boost {
 namespace urls {
-
-/** Rule for URI
-
-    @par Value Type
-    @code
-    using value_type = url_view;
-    @endcode
-
-    @par Example
-    Rules are used with the function @ref grammar::parse.
-    @code
-    system::result< url_view > rv = grammar::parse( "https://www.example.com/index.htm?id=guest#s1", uri_rule );
-    @endcode
-
-    @par BNF
-    @code
-    URI           = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
-    @endcode
-
-    @par Specification
-    @li <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3"
-        >3. Syntax Components (rfc3986)</a>
-
-    @see
-        @ref grammar::parse,
-        @ref parse_uri,
-        @ref url_view.
-*/
-#ifdef BOOST_URL_DOCS
-constexpr __implementation_defined__ uri_rule{};
-#else
 namespace implementation_defined {
 struct uri_rule_t
 {
@@ -90,7 +59,6 @@ struct uri_rule_t
         @ref url_view.
 */
 constexpr implementation_defined::uri_rule_t uri_rule{};
-#endif
 
 } // urls
 } // boost

--- a/include/boost/url/segments_base.hpp
+++ b/include/boost/url/segments_base.hpp
@@ -70,31 +70,7 @@ public:
         iterator is incremented, decremented,
         or destroyed.
     */
-#ifdef BOOST_URL_DOCS
-    using iterator = __see_below__;
-#else
-
-    /** A Bidirectional iterator to a path segment
-
-        Objects of this type allow iteration
-        through the segments in the path.
-        Any percent-escapes in returned strings
-        are decoded first.
-        The values returned are read-only;
-        changes to segments must be made
-        through the container instead, if the
-        container supports modification.
-
-        <br>
-
-        The strings produced when iterators are
-        dereferenced belong to the iterator and
-        become invalidated when that particular
-        iterator is incremented, decremented,
-        or destroyed.
-    */
     class iterator;
-#endif
 
     /// @copydoc iterator
     using const_iterator = iterator;

--- a/include/boost/url/segments_encoded_base.hpp
+++ b/include/boost/url/segments_encoded_base.hpp
@@ -73,34 +73,7 @@ public:
         it is no longer referenced by any
         container or iterator.
     */
-#ifdef BOOST_URL_DOCS
-    using iterator = __see_below__;
-#else
-
-    /** A Bidirectional iterator to a path segment
-
-        Objects of this type allow iteration
-        through the segments in the path.
-        Strings returned by iterators may
-        contain percent escapes.
-        The values returned are read-only;
-        changes to segments must be made
-        through the container instead, if the
-        container supports modification.
-
-        <br>
-
-        The strings produced when iterators
-        are dereferenced refer to the underlying
-        character buffer.
-        Ownership is not transferred; the caller
-        is responsible for ensuring that the
-        lifetime of the buffer extends until
-        it is no longer referenced by any
-        container or iterator.
-    */
     class iterator;
-#endif
 
     /// @copydoc iterator
     using const_iterator = iterator;

--- a/include/boost/url/url_base.hpp
+++ b/include/boost/url/url_base.hpp
@@ -30,7 +30,6 @@
 namespace boost {
 namespace urls {
 
-#ifndef BOOST_URL_DOCS
 namespace detail {
 struct any_params_iter;
 struct any_segments_iter;
@@ -38,7 +37,6 @@ struct params_iter_impl;
 struct segments_iter_impl;
 struct pattern;
 }
-#endif
 
 /** Common functionality for containers
 
@@ -73,9 +71,7 @@ class BOOST_URL_DECL
     friend class segments_ref;
     friend class segments_encoded_ref;
     friend class params_encoded_ref;
-#ifndef BOOST_URL_DOCS
     friend struct detail::pattern;
-#endif
 
     struct op_t
     {
@@ -250,7 +246,6 @@ public:
     url_base&
     set_scheme(core::string_view s);
 
-#ifndef BOOST_URL_DOCS
     /** Set the scheme
 
         This function sets the scheme to the specified
@@ -285,41 +280,6 @@ public:
     */
     url_base&
     set_scheme_id(urls::scheme id);
-#else
-    /** Set the scheme
-
-        This function sets the scheme to the specified
-        known @ref urls::scheme id, which may not be
-        @ref scheme::unknown or else an exception is
-        thrown. If the id is @ref scheme::none, this
-        function behaves as if @ref remove_scheme
-        were called.
-
-        @par Example
-        @code
-        assert( url( "http://example.com/echo.cgi" ).set_scheme_id( scheme::wss ).buffer() == "wss://example.com/echo.cgi" );
-        @endcode
-
-        @par Complexity
-        Linear in `this->size()`.
-
-        @par Exception Safety
-        Strong guarantee.
-        Calls to allocate may throw.
-        Exceptions thrown on invalid input.
-
-        @throw system_error
-        The scheme is invalid.
-
-        @param id The scheme to set.
-
-        @par Specification
-        @li <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.1">
-            3.1. Scheme (rfc3986)</a>
-    */
-    url_base&
-    set_scheme_id(scheme id);
-#endif
 
     /** Remove the scheme
 

--- a/src/rfc/query_rule.cpp
+++ b/src/rfc/query_rule.cpp
@@ -7,7 +7,6 @@
 // Official repository: https://github.com/boostorg/url
 //
 
-
 #include <boost/url/detail/config.hpp>
 #include <boost/url/rfc/query_rule.hpp>
 #include "detail/charsets.hpp"


### PR DESCRIPTION
This commit removes comments in the Doxygen documentation format from source files. This documentation format was there in a transition stage where we supported both Doxygen and MrDocs.

We only leave documentation in the MrDocs format now. This means the `BOOST_URL_DOCS` macro is no longer necessary: symbols are documented where they are defined instead of fake implementation defined symbols.