### PR TITLE
Docs: retry ui-bundle downloads

### DIFF
--- a/doc/package-lock.json
+++ b/doc/package-lock.json
@@ -10,6 +10,7 @@
         "@asciidoctor/tabs": "^1.0.0-beta.6",
         "@cppalliance/antora-cpp-reference-extension": "^0.1.0",
         "@cppalliance/antora-cpp-tagfiles-extension": "^0.1.0",
+        "@cppalliance/antora-downloads-extension": "^0.0.2",
         "@cppalliance/asciidoctor-boost-links": "^0.0.2"
       },
       "devDependencies": {
@@ -446,6 +447,12 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@cppalliance/antora-downloads-extension": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@cppalliance/antora-downloads-extension/-/antora-downloads-extension-0.0.2.tgz",
+      "integrity": "sha512-2wXahlvRz9J75ZSfzDeP4XpIZiqIm+w/YjmCWJxFPp6oWgP7e8f6ps7HqdtHNGxnK5mG38OjiCFdHjmHYfgbDA==",
+      "license": "BSL-1.0"
     },
     "node_modules/@cppalliance/asciidoctor-boost-links": {
       "version": "0.0.2",

--- a/doc/package.json
+++ b/doc/package.json
@@ -10,6 +10,7 @@
     "@asciidoctor/tabs": "^1.0.0-beta.6",
     "@cppalliance/antora-cpp-reference-extension": "^0.1.0",
     "@cppalliance/antora-cpp-tagfiles-extension": "^0.1.0",
+    "@cppalliance/antora-downloads-extension": "^0.0.2",
     "@cppalliance/asciidoctor-boost-links": "^0.0.2"
   }
 }


### PR DESCRIPTION
Any download during a CI build might potentially fail so it's convenient to retry. This PR includes a new extension "@cppalliance/antora-downloads-extension" with a retry loop for the ui-bundle.    