### PR TITLE
fix: example router is move-only

### DIFF
--- a/example/router/detail/router.hpp
+++ b/example/router/detail/router.hpp
@@ -39,6 +39,11 @@ protected:
 
     virtual ~router_base();
 
+    router_base(router_base const&) = delete;
+    router_base& operator=(router_base const&) = delete;
+    router_base(router_base&&) noexcept = default;
+    router_base& operator=(router_base&&) noexcept = default;
+
     void
     insert_impl(
         core::string_view s,

--- a/example/router/router.hpp
+++ b/example/router/router.hpp
@@ -54,6 +54,11 @@ public:
     /// Constructor
     router() = default;
 
+    router(router const&) = delete;
+    router& operator=(router const&) = delete;
+    router(router&&) noexcept = default;
+    router& operator=(router&&) noexcept = default;
+
     /** Route the specified URL path to a resource
 
         @param path A url path with dynamic segments
@@ -88,4 +93,3 @@ private:
 #include "impl/router.hpp"
 
 #endif
-

--- a/test/unit/example/router/router.cpp
+++ b/test/unit/example/router/router.cpp
@@ -16,8 +16,19 @@
 
 #include "test_suite.hpp"
 
+#include <type_traits>
+
 namespace boost {
 namespace urls {
+
+static_assert(!std::is_copy_constructible<router<int>>::value,
+    "router should be move-only");
+static_assert(!std::is_copy_assignable<router<int>>::value,
+    "router should be move-only");
+static_assert(std::is_move_constructible<router<int>>::value,
+    "router should support moves");
+static_assert(std::is_move_assignable<router<int>>::value,
+    "router should support moves");
 
 struct router_test
 {


### PR DESCRIPTION
fix #956