### PR TITLE
build(test): group test suite helper targets under Dependencies

### DIFF
--- a/extra/test_suite/CMakeLists.txt
+++ b/extra/test_suite/CMakeLists.txt
@@ -25,5 +25,6 @@ add_library(boost_url_test_suite_with_main STATIC test_main.cpp)
 target_link_libraries(boost_url_test_suite_with_main PUBLIC boost_url_test_suite)
 target_include_directories(boost_url_test_suite_with_main PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_features(boost_url_test_suite_with_main PUBLIC cxx_constexpr)
+set_property(TARGET boost_url_test_suite boost_url_test_suite_with_main PROPERTY FOLDER "Dependencies")
 
 include(DiscoverTests.cmake)


### PR DESCRIPTION
The test suite exposes two helper libraries (with and without a main), as with other test libraries, so other modules can choose their own entry point. Keeping both targets is necessary, but they clutter Visual Studio’s solution view.

Move these helper targets into the existing Dependencies folder to reduce noise while preserving the separate-linking behavior.

fix #955