### PR TITLE
feat: specialize enable_borrowed_range for view types

### DIFF
--- a/include/boost/url/decode_view.hpp
+++ b/include/boost/url/decode_view.hpp
@@ -1074,4 +1074,20 @@ make_decode_view(
 
 #include <boost/url/impl/decode_view.hpp>
 
+//------------------------------------------------
+//
+// std::ranges::enable_borrowed_range
+//
+//------------------------------------------------
+
+#ifdef BOOST_URL_HAS_CONCEPTS
+#include <ranges>
+namespace std::ranges {
+    template<>
+    inline constexpr bool
+        enable_borrowed_range<
+            boost::urls::decode_view> = true;
+} // std::ranges
+#endif
+
 #endif

--- a/include/boost/url/params_encoded_ref.hpp
+++ b/include/boost/url/params_encoded_ref.hpp
@@ -1005,4 +1005,20 @@ private:
 //
 // #include <boost/url/impl/params_encoded_ref.hpp>
 
+//------------------------------------------------
+//
+// std::ranges::enable_borrowed_range
+//
+//------------------------------------------------
+
+#ifdef BOOST_URL_HAS_CONCEPTS
+#include <ranges>
+namespace std::ranges {
+    template<>
+    inline constexpr bool
+        enable_borrowed_range<
+            boost::urls::params_encoded_ref> = true;
+} // std::ranges
+#endif
+
 #endif

--- a/include/boost/url/params_encoded_view.hpp
+++ b/include/boost/url/params_encoded_view.hpp
@@ -239,4 +239,20 @@ public:
 } // urls
 } // boost
 
+//------------------------------------------------
+//
+// std::ranges::enable_borrowed_range
+//
+//------------------------------------------------
+
+#ifdef BOOST_URL_HAS_CONCEPTS
+#include <ranges>
+namespace std::ranges {
+    template<>
+    inline constexpr bool
+        enable_borrowed_range<
+            boost::urls::params_encoded_view> = true;
+} // std::ranges
+#endif
+
 #endif

--- a/include/boost/url/params_ref.hpp
+++ b/include/boost/url/params_ref.hpp
@@ -961,4 +961,20 @@ private:
 //
 // #include <boost/url/impl/params_ref.hpp>
 
+//------------------------------------------------
+//
+// std::ranges::enable_borrowed_range
+//
+//------------------------------------------------
+
+#ifdef BOOST_URL_HAS_CONCEPTS
+#include <ranges>
+namespace std::ranges {
+    template<>
+    inline constexpr bool
+        enable_borrowed_range<
+            boost::urls::params_ref> = true;
+} // std::ranges
+#endif
+
 #endif

--- a/include/boost/url/params_view.hpp
+++ b/include/boost/url/params_view.hpp
@@ -287,4 +287,20 @@ public:
 } // urls
 } // boost
 
+//------------------------------------------------
+//
+// std::ranges::enable_borrowed_range
+//
+//------------------------------------------------
+
+#ifdef BOOST_URL_HAS_CONCEPTS
+#include <ranges>
+namespace std::ranges {
+    template<>
+    inline constexpr bool
+        enable_borrowed_range<
+            boost::urls::params_view> = true;
+} // std::ranges
+#endif
+
 #endif

--- a/include/boost/url/pct_string_view.hpp
+++ b/include/boost/url/pct_string_view.hpp
@@ -467,4 +467,14 @@ to_sv(pct_string_view const& s) noexcept
 // Ensure decode_view is complete for operator*()
 #include <boost/url/decode_view.hpp>
 
+#ifdef BOOST_URL_HAS_CONCEPTS
+#include <ranges>
+namespace std::ranges {
+    template<>
+    inline constexpr bool
+        enable_borrowed_range<
+            boost::urls::pct_string_view> = true;
+} // std::ranges
+#endif
+
 #endif

--- a/include/boost/url/segments_encoded_ref.hpp
+++ b/include/boost/url/segments_encoded_ref.hpp
@@ -794,4 +794,20 @@ private:
 //
 // #include <boost/url/impl/segments_encoded_ref.hpp>
 
+//------------------------------------------------
+//
+// std::ranges::enable_borrowed_range
+//
+//------------------------------------------------
+
+#ifdef BOOST_URL_HAS_CONCEPTS
+#include <ranges>
+namespace std::ranges {
+    template<>
+    inline constexpr bool
+        enable_borrowed_range<
+            boost::urls::segments_encoded_ref> = true;
+} // std::ranges
+#endif
+
 #endif

--- a/include/boost/url/segments_encoded_view.hpp
+++ b/include/boost/url/segments_encoded_view.hpp
@@ -307,4 +307,20 @@ public:
 } // urls
 } // boost
 
+//------------------------------------------------
+//
+// std::ranges::enable_borrowed_range
+//
+//------------------------------------------------
+
+#ifdef BOOST_URL_HAS_CONCEPTS
+#include <ranges>
+namespace std::ranges {
+    template<>
+    inline constexpr bool
+        enable_borrowed_range<
+            boost::urls::segments_encoded_view> = true;
+} // std::ranges
+#endif
+
 #endif

--- a/include/boost/url/segments_ref.hpp
+++ b/include/boost/url/segments_ref.hpp
@@ -740,4 +740,20 @@ private:
 //
 // #include <boost/url/impl/segments_ref.hpp>
 
+//------------------------------------------------
+//
+// std::ranges::enable_borrowed_range
+//
+//------------------------------------------------
+
+#ifdef BOOST_URL_HAS_CONCEPTS
+#include <ranges>
+namespace std::ranges {
+    template<>
+    inline constexpr bool
+        enable_borrowed_range<
+            boost::urls::segments_ref> = true;
+} // std::ranges
+#endif
+
 #endif

--- a/include/boost/url/segments_view.hpp
+++ b/include/boost/url/segments_view.hpp
@@ -259,4 +259,20 @@ public:
 } // urls
 } // boost
 
+//------------------------------------------------
+//
+// std::ranges::enable_borrowed_range
+//
+//------------------------------------------------
+
+#ifdef BOOST_URL_HAS_CONCEPTS
+#include <ranges>
+namespace std::ranges {
+    template<>
+    inline constexpr bool
+        enable_borrowed_range<
+            boost::urls::segments_view> = true;
+} // std::ranges
+#endif
+
 #endif

--- a/test/unit/decode_view.cpp
+++ b/test/unit/decode_view.cpp
@@ -354,6 +354,25 @@ struct decode_view_test
     }
 
     void
+    testBorrowedRange()
+    {
+#ifdef BOOST_URL_HAS_CONCEPTS
+        // decode_view is a borrowed range
+        BOOST_CORE_STATIC_ASSERT(
+            std::ranges::borrowed_range<decode_view>);
+
+        // iterators remain valid after the view is destroyed
+        decode_view::iterator it;
+        {
+            decode_view dv("hello%20world");
+            it = dv.begin();
+        }
+        // iterator is still valid (points to external buffer)
+        BOOST_TEST_EQ(*it, 'h');
+#endif
+    }
+
+    void
     run()
     {
         testDecodeView();
@@ -365,6 +384,7 @@ struct decode_view_test
         testCompare();
         testStream();
         testPR127Cases();
+        testBorrowedRange();
     }
 };
 

--- a/test/unit/params_encoded_ref.cpp
+++ b/test/unit/params_encoded_ref.cpp
@@ -771,12 +771,34 @@ struct params_encoded_ref_test
     }
 
     void
+    testBorrowedRange()
+    {
+#ifdef BOOST_URL_HAS_CONCEPTS
+        // params_encoded_ref is a borrowed range
+        BOOST_CORE_STATIC_ASSERT(
+            std::ranges::borrowed_range<params_encoded_ref>);
+
+        // iterators remain valid after the ref is destroyed
+        // (as long as the underlying url stays alive)
+        url u("?first=John&last=Doe");
+        params_encoded_ref::iterator it;
+        {
+            params_encoded_ref p = u.encoded_params();
+            it = p.begin();
+        }
+        // ref is destroyed, but iterator is still valid
+        BOOST_TEST_EQ((*it).key, "first");
+#endif
+    }
+
+    void
     run()
     {
         testSpecial();
         testObservers();
         testModifiers();
         testJavadocs();
+        testBorrowedRange();
     }
 };
 

--- a/test/unit/params_encoded_view.cpp
+++ b/test/unit/params_encoded_view.cpp
@@ -215,11 +215,31 @@ struct params_encoded_view_test
     }
 
     void
+    testBorrowedRange()
+    {
+#ifdef BOOST_URL_HAS_CONCEPTS
+        // params_encoded_view is a borrowed range
+        BOOST_CORE_STATIC_ASSERT(
+            std::ranges::borrowed_range<params_encoded_view>);
+
+        // iterators remain valid after the view is destroyed
+        params_encoded_view::iterator it;
+        {
+            params_encoded_view qp("first=John&last=Doe");
+            it = qp.begin();
+        }
+        // iterator is still valid (points to external buffer)
+        BOOST_TEST_EQ((*it).key, "first");
+#endif
+    }
+
+    void
     run()
     {
         testMembers();
         testRange();
         testJavadocs();
+        testBorrowedRange();
     }
 };
 

--- a/test/unit/params_ref.cpp
+++ b/test/unit/params_ref.cpp
@@ -1034,6 +1034,28 @@ struct params_ref_test
 
     static
     void
+    testBorrowedRange()
+    {
+#ifdef BOOST_URL_HAS_CONCEPTS
+        // params_ref is a borrowed range
+        BOOST_CORE_STATIC_ASSERT(
+            std::ranges::borrowed_range<params_ref>);
+
+        // iterators remain valid after the ref is destroyed
+        // (as long as the underlying url stays alive)
+        url u("?first=John&last=Doe");
+        params_ref::iterator it;
+        {
+            params_ref p = u.params();
+            it = p.begin();
+        }
+        // ref is destroyed, but iterator is still valid
+        BOOST_TEST_EQ((*it).key, "first");
+#endif
+    }
+
+    static
+    void
     testAll()
     {
         testSpecial();
@@ -1041,6 +1063,7 @@ struct params_ref_test
         testModifiers();
         testJavadocs();
         testSpaceAsPlus();
+        testBorrowedRange();
     }
 
     void

--- a/test/unit/params_view.cpp
+++ b/test/unit/params_view.cpp
@@ -143,10 +143,30 @@ struct params_view_test
     }
 
     void
+    testBorrowedRange()
+    {
+#ifdef BOOST_URL_HAS_CONCEPTS
+        // params_view is a borrowed range
+        BOOST_CORE_STATIC_ASSERT(
+            std::ranges::borrowed_range<params_view>);
+
+        // iterators remain valid after the view is destroyed
+        params_view::iterator it;
+        {
+            params_view qp("first=John&last=Doe");
+            it = qp.begin();
+        }
+        // iterator is still valid (points to external buffer)
+        BOOST_TEST_EQ((*it).key, "first");
+#endif
+    }
+
+    void
     run()
     {
         testMembers();
         testJavadocs();
+        testBorrowedRange();
     }
 };
 

--- a/test/unit/pct_string_view.cpp
+++ b/test/unit/pct_string_view.cpp
@@ -10,6 +10,7 @@
 // Test that header file is self-contained.
 #include <boost/url/pct_string_view.hpp>
 
+#include <boost/core/detail/static_assert.hpp>
 #include "test_suite.hpp"
 
 namespace boost {
@@ -159,11 +160,31 @@ struct pct_string_view_test
     }
 
     void
+    testBorrowedRange()
+    {
+#ifdef BOOST_URL_HAS_CONCEPTS
+        // pct_string_view is a borrowed range
+        BOOST_CORE_STATIC_ASSERT(
+            std::ranges::borrowed_range<pct_string_view>);
+
+        // iterators remain valid after the view is destroyed
+        pct_string_view::iterator it;
+        {
+            pct_string_view psv("hello%20world");
+            it = psv.begin();
+        }
+        // iterator is still valid (points to external buffer)
+        BOOST_TEST_EQ(*it, 'h');
+#endif
+    }
+
+    void
     run()
     {
         testSpecial();
         testRelation();
         testOperatorStar();
+        testBorrowedRange();
     }
 };
 

--- a/test/unit/segments_encoded_ref.cpp
+++ b/test/unit/segments_encoded_ref.cpp
@@ -828,6 +828,27 @@ struct segments_encoded_ref_test
     }
 
     void
+    testBorrowedRange()
+    {
+#ifdef BOOST_URL_HAS_CONCEPTS
+        // segments_encoded_ref is a borrowed range
+        BOOST_CORE_STATIC_ASSERT(
+            std::ranges::borrowed_range<segments_encoded_ref>);
+
+        // iterators remain valid after the ref is destroyed
+        // (as long as the underlying url stays alive)
+        url u("/path/to/file.txt");
+        segments_encoded_ref::iterator it;
+        {
+            segments_encoded_ref s = u.encoded_segments();
+            it = s.begin();
+        }
+        // ref is destroyed, but iterator is still valid
+        BOOST_TEST_EQ(*it, "path");
+#endif
+    }
+
+    void
     run()
     {
         testSpecial();
@@ -835,6 +856,7 @@ struct segments_encoded_ref_test
         testModifiers();
         testEditSegments();
         testJavadocs();
+        testBorrowedRange();
     }
 };
 

--- a/test/unit/segments_encoded_view.cpp
+++ b/test/unit/segments_encoded_view.cpp
@@ -192,10 +192,30 @@ struct segments_const_encoded_view_test
     }
 
     void
+    testBorrowedRange()
+    {
+#ifdef BOOST_URL_HAS_CONCEPTS
+        // segments_encoded_view is a borrowed range
+        BOOST_CORE_STATIC_ASSERT(
+            std::ranges::borrowed_range<segments_encoded_view>);
+
+        // iterators remain valid after the view is destroyed
+        segments_encoded_view::iterator it;
+        {
+            segments_encoded_view ps("/path/to/file.txt");
+            it = ps.begin();
+        }
+        // iterator is still valid (points to external buffer)
+        BOOST_TEST_EQ(*it, "path");
+#endif
+    }
+
+    void
     run()
     {
         testSpecialMembers();
         testJavadocs();
+        testBorrowedRange();
     }
 };
 

--- a/test/unit/segments_ref.cpp
+++ b/test/unit/segments_ref.cpp
@@ -845,12 +845,35 @@ struct segments_ref_test
 
     static
     void
+    testBorrowedRange()
+    {
+#ifdef BOOST_URL_HAS_CONCEPTS
+        // segments_ref is a borrowed range
+        BOOST_CORE_STATIC_ASSERT(
+            std::ranges::borrowed_range<segments_ref>);
+
+        // iterators remain valid after the ref is destroyed
+        // (as long as the underlying url stays alive)
+        url u("/path/to/file.txt");
+        segments_ref::iterator it;
+        {
+            segments_ref s = u.segments();
+            it = s.begin();
+        }
+        // ref is destroyed, but iterator is still valid
+        BOOST_TEST_EQ(*it, "path");
+#endif
+    }
+
+    static
+    void
     testAll()
     {
         testSpecial();
         testObservers();
         testModifiers();
         testJavadocs();
+        testBorrowedRange();
     }
 
     void

--- a/test/unit/segments_view.cpp
+++ b/test/unit/segments_view.cpp
@@ -387,11 +387,31 @@ struct segments_view_test
     }
 
     void
+    testBorrowedRange()
+    {
+#ifdef BOOST_URL_HAS_CONCEPTS
+        // segments_view is a borrowed range
+        BOOST_CORE_STATIC_ASSERT(
+            std::ranges::borrowed_range<segments_view>);
+
+        // iterators remain valid after the view is destroyed
+        segments_view::iterator it;
+        {
+            segments_view ps("/path/to/file.txt");
+            it = ps.begin();
+        }
+        // iterator is still valid (points to external buffer)
+        BOOST_TEST_EQ(*it, "path");
+#endif
+    }
+
+    void
     run()
     {
         testSpecialMembers();
         testRangeCtor();
         testJavadocs();
+        testBorrowedRange();
     }
 };
 


### PR DESCRIPTION
All view types in Boost.URL have iterators that store raw pointers to external data rather than references to the view object itself. This means iterators remain valid even after the view is destroyed.

fix #927