### PR TITLE
fix: normalize_path overflow shielding "//" path

### DIFF
--- a/include/boost/url/impl/url_base.hpp
+++ b/include/boost/url/impl/url_base.hpp
@@ -2149,10 +2149,11 @@ normalize_path()
     // remove_dot_segments can produce output that
     // needs a 2-byte shield prefix, as explained
     // in step 2. The memmove below writes within
-    // the original path region (before shrink_impl)
-    // and always has room because ".." cancellation
-    // consumes >= 5 bytes but we only need 2 for the
-    // shield.
+    // the path region; when ".." cancellation has
+    // consumed >= 2 bytes there is already slack,
+    // but for short inputs that take the shield
+    // branch without any cancellation (e.g. "//"),
+    // the region has to grow to fit the prefix.
     //
     bool needs_shield = [&]()
     {
@@ -2204,7 +2205,14 @@ normalize_path()
     }();
     if (needs_shield)
     {
-        BOOST_ASSERT(n + 2 <= pn);
+        if (n + 2 > pn)
+        {
+            // No "..  cancellation slack — grow the path
+            // region to fit the 2-byte shield. p_dest may
+            // be invalidated by the underlying reallocation.
+            p_dest = resize_impl(id_path, n + 2, op);
+            pn = n + 2;
+        }
         std::memmove(p_dest + 2, p_dest, n);
         if (was_absolute)
         {

--- a/test/unit/url.cpp
+++ b/test/unit/url.cpp
@@ -1333,6 +1333,21 @@ struct url_test
             check("", "");
         }
 
+        // normalize path without authority: a "//" path must
+        // grow the buffer before prepending the "/." shield.
+        // https://github.com/boostorg/url/issues/992
+        {
+            auto check = [](core::string_view p,
+                            core::string_view e) {
+                url u = parse_origin_form(p).value();
+                u.normalize();
+                BOOST_TEST_EQ(u.encoded_path(), e);
+            };
+            check("//", "/.//");
+            check("///", "/.///");
+            check("////", "/.////");
+        }
+
         // inequality
         {
             auto check = [](core::string_view e1,


### PR DESCRIPTION
Closes #992.

## Problem

```cpp
auto u = boost::urls::parse_origin_form("//").value();
boost::urls::url{u}.normalize();
```

triggers `BOOST_ASSERT(n + 2 <= pn)` in `url_base::normalize_path` (`include/boost/url/impl/url_base.hpp:2207`). With assertions disabled the subsequent `memmove` writes past the end of the path region — a real heap buffer overflow.

## Root cause

When the URL has no authority and the normalized path starts with `//`, `normalize_path` prepends a 2-byte `/.` shield so the round-tripped string isn't re-parsed as an authority. The pre-existing comment claimed this `memmove` always has room because `..` cancellation consumes ≥ 5 bytes, and the shield only needs 2.

That's true for the cancellation case (`/a/..//x` → `/x` → `/.//x`, with slack from the canceled segments). It's **not** true for short inputs that hit the shield branch with **no** cancellation:

- `"//"` (`pn = 2`, `n = 2`) — wants 4 bytes for `/.//`
- `"///"` (`pn = 3`, `n = 3`) — wants 5 bytes for `/.///`
- ...

`parse_origin_form` produces exactly such paths (origin-form has no authority).

## Fix

`include/boost/url/impl/url_base.hpp:2205-2222` — before the `memmove`, grow the path region with `resize_impl(id_path, n + 2, op)` when `n + 2 > pn`. Re-read `p_dest` from the resize return value (the underlying storage may have moved) and update `pn` so the later `if (n != pn)` shrink branch behaves correctly.

The surrounding comment was updated: the shield branch now requires *either* ≥ 2 bytes of cancellation slack *or* a buffer grow, instead of the previous overstated invariant.

## Tests

`test/unit/url.cpp` — a new block in the existing normalize-path section asserts:

```cpp
parse_origin_form("//").value().normalize().encoded_path()   == "/.//"
parse_origin_form("///").value().normalize().encoded_path()  == "/.///"
parse_origin_form("////").value().normalize().encoded_path() == "/.////"
```

The first case is the exact reproducer from the issue. The other two cover the same shieldless-`//` family with extra trailing slashes.

All 42324 unit-test assertions and 79 ctest entries pass locally under C++20 (`./test_all.sh` patterns).
