### PR TITLE
Documentation fixes for the Quick Look and Parsing pages

### DIFF
--- a/doc/modules/ROOT/pages/quicklook.adoc
+++ b/doc/modules/ROOT/pages/quicklook.adoc
@@ -242,6 +242,8 @@ This is also useful when manipulating URLs:
 
 [source,cpp]
 ----
+url      u1 = parse_uri( "http://www.example.com" ).value();
+url_view u2 = parse_uri( "http://other.example.com" ).value();
 u1.set_host(u2.host());
 ----
 

--- a/doc/modules/ROOT/pages/quicklook.adoc
+++ b/doc/modules/ROOT/pages/quicklook.adoc
@@ -315,7 +315,7 @@ Output::
 ----
 path
 to
-my-file.txt
+my%2dfile.txt
 ----
 --
 ====

--- a/doc/modules/ROOT/pages/urls/parsing.adoc
+++ b/doc/modules/ROOT/pages/urls/parsing.adoc
@@ -104,6 +104,8 @@ https://datatracker.ietf.org/doc/html/rfc3986#section-3[__URI__,window=blank_]:
 [source,cpp]
 ----
 include::example$unit/snippets.cpp[tag=code_urls_parsing_1,indent=0]
+
+include::example$unit/snippets.cpp[tag=code_urls_parsing_2,indent=0]
 ----
 
 The function returns a cpp:result[] which holds a cpp:url_view[]
@@ -117,15 +119,19 @@ The caller is responsible for ensuring that the lifetime of the character buffer
 These are the same semantics as that of cpp:std::string_view[].
 ====
 
-For convenience, a URL view can be constructed directly from the character buffer in a cpp:string_view[].
-In this case, it parses the string according to the
-https://datatracker.ietf.org/doc/html/rfc3986#section-4.1[__URI-reference__,window=blank_]
-grammar, throwing an exception upon failure.
-The following two statements are equivalent:
+We can immediately call cpp:result::value[] to obtain a cpp:url_view[]:
 
 [source,cpp]
 ----
-include::example$unit/snippets.cpp[tag=code_urls_parsing_2,indent=0]
+include::example$unit/snippets.cpp[tag=snippet_parsing_3,indent=0]
+----
+
+Or, on a result that is known to hold a value, the shorter
+cpp:result::operator*[]:
+
+[source,cpp]
+----
+include::example$unit/snippets.cpp[tag=snippet_parsing_4,indent=0]
 ----
 
 In this library, free functions which parse things are named with the word "parse" followed by the name of the grammar used to match the string.


### PR DESCRIPTION
Closes #996, #997, #998.

Three small, self-contained fixes to the docs reported by the same author.

## #996 — `u1.set_host(u2.host())` example doesn't compile

`doc/modules/ROOT/pages/quicklook.adoc` showed:

```cpp
u1.set_host(u2.host());
```

with `u1` introduced as a `url_view` in the surrounding prose. `url_view` is immutable, so the snippet doesn't compile. The example is a raw `[source,cpp]` block (not an `include::` of a tested snippet), so the fix is to make the freestanding code self-contained:

```cpp
url      u1 = parse_uri( "http://www.example.com" ).value();
url_view u2 = parse_uri( "http://other.example.com" ).value();
u1.set_host(u2.host());
```

`u1` is now a `url` (mutable), which is what `set_host` requires.

## #997 — encoded vs decoded segments produced the same output

In `quicklook.adoc`, the "encoded segments" section claimed the loop prints:

```
path
to
my-file.txt
```

But the tested snippet asserts:

```cpp
BOOST_TEST(equal_range(segs_encoded, {"path", "to", "my%2dfile.txt"}));
```

i.e. the actual library output is `my%2dfile.txt` — the encoded form. The doc was showing the *decoded* string in the "encoded" block, making the two adjacent examples look identical. Updated the block to match what the snippet actually prints.

## #998 — "parses a string literal" intro didn't show the parse

`doc/modules/ROOT/pages/urls/parsing.adoc` opened with:

> The following example parses a string literal containing a URI: `[code_urls_parsing_1]`

`code_urls_parsing_1` is only the `string_view` declaration — no `parse_uri` call. Further down the same page, the prose "The following two statements are equivalent:" was paired with `code_urls_parsing_2`, which is a single `parse_uri` call (not two statements at all). The blocks were transposed.

Reorganised so the intro shows both `code_urls_parsing_1` (string) and `code_urls_parsing_2` (`parse_uri` call) in one fenced block — making the "parses a string literal" wording accurate — and the "two equivalent statements" section now correctly pairs `snippet_parsing_3` (`r.value()`) and `snippet_parsing_4` (`*r`), which *are* the two equivalent ways to obtain the `url_view` from the result.

Verified the Antora build (`doc/build_antora.sh`) renders both blocks correctly.

## Follow-up: orphan snippets

While verifying #998 I ran a tags-defined vs tags-included comparison and found **112 snippet tags compiled and tested but never included in any page**. Largest clusters: `snippet_parsing_path_*` (22), `snippet_parsing_authority_*` (21), `snippet_parsing_query_*` (16), `snippet_modifying_path_*` (15). The kind of misalignment that produced #998 is structurally invisible today.

Filed as a separate issue with a proposed CI lint to prevent regressions. Not in this PR's scope.
