### PR TITLE
[doc] Name the template parameter of grammar::ref

### DIFF
--- a/include/boost/url/grammar/charset.hpp
+++ b/include/boost/url/grammar/charset.hpp
@@ -253,7 +253,7 @@ struct charset_ref
     `ref` should only be used with compile-time
     constants.
 
-    @tparam CharSet The character set type
+    @tparam CS The character set type
     @param cs The character set to use
     @return The character set as a reference type
 */


### PR DESCRIPTION
```cpp
    @tparam CharSet The character set type
*/
template<BOOST_URL_CONSTRAINT(CharSet) CS>
constexpr ... ref(CS const& cs) noexcept
```

`BOOST_URL_CONSTRAINT(C)` expands to `C` when concepts are available and to `class` otherwise, so the template parameter is `CS` in both modes and `CharSet` is the concept constraining it. Doxygen therefore has `CS` undocumented and `CharSet` pointing at nothing.

This is the only `@tparam` in the library that sits on that macro, so there is no convention here I would be breaking. The description stays as it was.

Not in this pull request: `extra/test_suite/test_suite.hpp:86` documents `@param suite` on `virtual void insert(any_suite const&) = 0`, whose argument has no name. It is test scaffolding rather than library code, so I left it alone. Say the word if you want it too.
